### PR TITLE
Add Event class and Implement add_event command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLATFORM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Event;
+
+/**
+ * Adds a person to the address book.
+ */
+public class AddEventCommand extends Command {
+
+    public static final String COMMAND_WORD = "add_event";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an event to the address book. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_COMPANY + "COMPANY "
+            + PREFIX_DATE + "DATE "
+            + PREFIX_TIME + "TIME "
+            + PREFIX_PLATFORM + "PLATFORM "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Interview "
+            + PREFIX_COMPANY + "ABC "
+            + PREFIX_DATE + "12-12-2022 "
+            + PREFIX_TIME + "13:30 "
+            + PREFIX_PLATFORM + "zoom "
+            + PREFIX_TAG + "technical "
+            + PREFIX_TAG + "coding";
+
+    public static final String MESSAGE_SUCCESS = "New event added: %1$s";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book";
+
+    private final Event toAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public AddEventCommand(Event event) {
+        requireNonNull(event);
+        toAdd = event;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasEvent(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        }
+
+        model.addEvent(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddEventCommand // instanceof handles nulls
+                && toAdd.equals(((AddEventCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PLATFORM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.entry.Date;
+import seedu.address.model.entry.Event;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Platform;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.entry.Time;
+
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddEventCommandParser implements Parser<AddEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddEventCommand
+     * and returns an AddEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddEventCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COMPANY,
+                        PREFIX_DATE, PREFIX_TIME, PREFIX_PLATFORM, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_COMPANY,
+                PREFIX_DATE, PREFIX_TIME, PREFIX_PLATFORM)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddEventCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        String company = ParserUtil.parseCompanyName(argMultimap.getValue(PREFIX_COMPANY).get());
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Time time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
+        Platform platform = ParserUtil.parsePlatform(argMultimap.getValue(PREFIX_PLATFORM).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Event event = new Event(name, company, date, time, platform, tagList);
+
+        return new AddEventCommand(event);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddEventCommand.COMMAND_WORD:
+            return new AddEventCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,9 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_COMPANY = new Prefix("c/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_TIME = new Prefix("ti/");
+    public static final Prefix PREFIX_PLATFORM = new Prefix("pl/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,9 +10,12 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entry.Address;
+import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Email;
 import seedu.address.model.entry.Name;
 import seedu.address.model.entry.Phone;
+import seedu.address.model.entry.Platform;
+import seedu.address.model.entry.Time;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -120,5 +123,44 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    public static String parseCompanyName(String companyName) throws ParseException {
+        requireNonNull(companyName);
+        String trimmedCompanyName = companyName.trim();
+        if(trimmedCompanyName.equals("")) {
+            throw new ParseException("Company name cannot be empty");
+        }
+//        if (!Email.isValidEmail(trimmedEmail)) {
+//            throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+//        }
+        return trimmedCompanyName;
+    }
+
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmeddate = date.trim();
+        if (!Date.isValidDate(trimmeddate)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Date(trimmeddate);
+    }
+
+    public static Time parseTime(String time) throws ParseException {
+        requireNonNull(time);
+        String trimmedTime = time.trim();
+        if (!Time.isValidTime(trimmedTime)) {
+            throw new ParseException(Time.MESSAGE_CONSTRAINTS);
+        }
+        return new Time(time);
+    }
+
+    public static Platform parsePlatform(String platform) throws ParseException {
+        requireNonNull(platform);
+        String trimmedPlatform = platform.trim();
+        if (!Platform.isValidPlatform(trimmedPlatform)) {
+            throw new ParseException(Platform.MESSAGE_CONSTRAINTS);
+        }
+        return new Platform(trimmedPlatform);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,8 +3,10 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 import seedu.address.model.entry.UniqueEntryList;
 
@@ -15,6 +17,7 @@ import seedu.address.model.entry.UniqueEntryList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueEntryList<Person> persons;
+    private final UniqueEntryList<Event> events;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +28,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniqueEntryList<Person>();
+        events = new UniqueEntryList<Event>();
     }
 
     public AddressBook() {}
@@ -54,6 +58,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setEvents(newData.getEventList());
     }
 
     //// person-level operations
@@ -97,7 +102,8 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public String toString() {
-        return persons.asUnmodifiableObservableList().size() + " persons";
+        return persons.asUnmodifiableObservableList().size() + " persons "
+                + events.asUnmodifiableObservableList().size() + " events";
         // TODO: refine later
     }
 
@@ -110,11 +116,37 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+                && persons.equals(((AddressBook) other).persons)
+                && events.equals(((AddressBook) other).events));
     }
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return Objects.hash(persons, events);
     }
+
+
+    public void setEvents(List<Event> events) {
+        this.events.setEntries(events);
+    }
+    public boolean hasEvent(Event event) {
+        requireNonNull(event);
+        return events.contains(event);
+    }
+    public void addEvent(Event e) {
+        events.add(e);
+    }
+    public void setEvent(Event target, Event editedEvent) {
+        requireNonNull(editedEvent);
+
+        events.setEntry(target, editedEvent);
+    }
+    public void removeEvent(Event key) {
+        events.remove(key);
+    }
+    @Override
+    public ObservableList<Event> getEventList() {
+        return events.asUnmodifiableObservableList();
+    }
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 
 /**
@@ -84,4 +85,16 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+
+    Predicate<Event> PREDICATE_SHOW_ALL_EVENTS = unused -> true;
+    boolean hasEvent(Event event);
+    void deleteEvent(Event target);
+    void addEvent(Event event);
+    void setEvent(Event target, Event editedEvent);
+    ObservableList<Event> getFilteredEventList();
+    void updateFilteredEventList(Predicate<Event> predicate);
+
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Event> filteredEvents;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredEvents = new FilteredList<>(this.addressBook.getEventList());
     }
 
     public ModelManager() {
@@ -147,4 +150,43 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(other.filteredPersons);
     }
 
+    //=========== For Events =================================================================================
+
+    @Override
+    public boolean hasEvent(Event event) {
+        requireNonNull(event);
+        return addressBook.hasEvent(event);
+    }
+
+    @Override
+    public void deleteEvent(Event target) {
+        addressBook.removeEvent(target);
+    }
+
+    @Override
+    public void addEvent(Event event) {
+        addressBook.addEvent(event);
+        updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+    }
+
+    @Override
+    public void setEvent(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+
+        addressBook.setEvent(target, editedEvent);
+    }
+
+
+    @Override
+    public ObservableList<Event> getFilteredEventList() {
+        return filteredEvents;
+    }
+
+    public void updateFilteredEventList(Predicate<Event> predicate) {
+        requireNonNull(predicate);
+        filteredEvents.setPredicate(predicate);
+    }
+
 }
+
+

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 
 /**
@@ -13,5 +14,7 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    ObservableList<Event> getEventList();
 
 }

--- a/src/main/java/seedu/address/model/entry/Date.java
+++ b/src/main/java/seedu/address/model/entry/Date.java
@@ -1,0 +1,59 @@
+package seedu.address.model.entry;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Event's Date in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
+ */
+public class Date {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "TODO CONSTRAINTS";
+
+    /*
+     * TODO VALIDATION REGEX
+     */
+//    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String date;
+
+    /**
+     * Constructs a {@code Date}.
+     *
+     * @param date A valid date.
+     */
+    public Date(String date) {
+        requireNonNull(date);
+        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        this.date = date;
+    }
+
+    /**
+     * Returns true if a given string is a valid date.
+     */
+    public static boolean isValidDate(String test) {
+        //return test.matches(VALIDATION_REGEX);
+        return true;
+    }
+
+
+    @Override
+    public String toString() {
+        return date;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Date // instanceof handles nulls
+                && date.equals(((Date) other).date)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return date.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -1,0 +1,106 @@
+package seedu.address.model.entry;
+
+import seedu.address.model.tag.Tag;
+
+
+import java.util.Objects;
+import java.util.Set;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+public class Event extends Entry {
+
+    //Identity fields
+    private final String company;
+
+    // Data fields
+    private final String date;
+    private final String time;
+    private final String platform;
+
+    public Event(Name name, String company, String date, String time, String platform, Set<Tag> tags) {
+        super(name, tags);
+        requireAllNonNull(company, date, time, platform);
+        this.company = company;
+        this.date = date;
+        this.time = time;
+        this.platform = platform;
+    }
+
+    public String getCompany() {
+        return this.company;
+    }
+
+    public String getDate() {
+        return this.date;
+    }
+
+    public String getTime() {
+        return this.time;
+    }
+
+    public String getPlatform() {
+        return this.platform;
+    }
+
+    @Override
+    public boolean isSameEntry(Entry otherEntry) {
+        if(otherEntry == this) {
+            return true;
+        }
+
+        if(!(otherEntry instanceof Event)) {
+            return false;
+        }
+
+        Event otherEvent = (Event) otherEntry;
+        return otherEvent.getName().equals(getName());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if(other == this) {
+            return true;
+        }
+
+        if(!(other instanceof Event)) {
+            return false;
+        }
+
+        Event otherEvent = (Event) other;
+        return otherEvent.getName().equals(getName())
+                && otherEvent.getCompany().equals(getCompany())
+                && otherEvent.getDate().equals(getDate())
+                && otherEvent.getTime().equals(getTime())
+                && otherEvent.getPlatform().equals(getPlatform())
+                && otherEvent.getTags().equals(getTags());
+    }
+
+    @Override
+    public int hashCode() {
+        // Use all Event's attributes to get a unique hashCode
+        return Objects.hash(getName(), company, date, time, platform, getTags());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append("; Company: ")
+                .append(getCompany())
+                .append("; Date: ")
+                .append(getDate())
+                .append("; Time: ")
+                .append(getTime())
+                .append("; Platform: ")
+                .append(getPlatform());
+
+        Set<Tag> tags = getTags();
+        if(!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+
+        return builder.toString();
+    }
+}

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -54,7 +54,8 @@ public class Event extends Entry {
         }
 
         Event otherEvent = (Event) otherEntry;
-        return otherEvent.getName().equals(getName());
+        return otherEvent.getName().equals(getName())
+                && otherEvent.getCompany().equals(getCompany());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -14,11 +14,11 @@ public class Event extends Entry {
     private final String company;
 
     // Data fields
-    private final String date;
-    private final String time;
-    private final String platform;
+    private final Date date;
+    private final Time time;
+    private final Platform platform;
 
-    public Event(Name name, String company, String date, String time, String platform, Set<Tag> tags) {
+    public Event(Name name, String company, Date date, Time time, Platform platform, Set<Tag> tags) {
         super(name, tags);
         requireAllNonNull(company, date, time, platform);
         this.company = company;
@@ -31,15 +31,15 @@ public class Event extends Entry {
         return this.company;
     }
 
-    public String getDate() {
+    public Date getDate() {
         return this.date;
     }
 
-    public String getTime() {
+    public Time getTime() {
         return this.time;
     }
 
-    public String getPlatform() {
+    public Platform getPlatform() {
         return this.platform;
     }
 

--- a/src/main/java/seedu/address/model/entry/Platform.java
+++ b/src/main/java/seedu/address/model/entry/Platform.java
@@ -1,0 +1,60 @@
+package seedu.address.model.entry;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Event's Platform in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidPlatform(String)}
+ */
+public class Platform {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "TODO CONSTRAINTS";
+
+    /*
+     * TODO VALIDATION REGEX
+     */
+//    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String platform;
+
+    /**
+     * Constructs a {@code Platform}.
+     *
+     * @param platform A valid platform.
+     */
+    public Platform(String platform) {
+        requireNonNull(platform);
+        checkArgument(isValidPlatform(platform), MESSAGE_CONSTRAINTS);
+        this.platform = platform;
+    }
+
+    /**
+     * Returns true if a given string is a valid platform.
+     * TODO
+     */
+    public static boolean isValidPlatform(String test) {
+        //return test.matches(VALIDATION_REGEX);
+        return true;
+    }
+
+
+    @Override
+    public String toString() {
+        return platform;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Date // instanceof handles nulls
+                && platform.equals(((Platform) other).platform)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return platform.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/entry/Time.java
+++ b/src/main/java/seedu/address/model/entry/Time.java
@@ -1,0 +1,60 @@
+package seedu.address.model.entry;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Event's Time in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidTime(String)}
+ */
+public class Time {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "TODO CONSTRAINTS";
+
+    /*
+     * TODO VALIDATION REGEX
+     */
+//    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String time;
+
+    /**
+     * Constructs a {@code Time}.
+     *
+     * @param time A valid time.
+     */
+    public Time(String time) {
+        requireNonNull(time);
+        checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
+        this.time = time;
+    }
+
+    /**
+     * Returns true if a given string is a valid time.
+     * TODO
+     */
+    public static boolean isValidTime(String test) {
+        //return test.matches(VALIDATION_REGEX);
+        return true;
+    }
+
+
+    @Override
+    public String toString() {
+        return time;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Time // instanceof handles nulls
+                && time.equals(((Time) other).time)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return time.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -1,0 +1,126 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.Date;
+import seedu.address.model.entry.Event;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Platform;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.entry.Time;
+
+/**
+ * Jackson-friendly version of {@link Event}.
+ */
+class JsonAdaptedEvent {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Event's %s field is missing!";
+
+    private final String name;
+    private final String company;
+    private final String date;
+    private final String time;
+    private final String platform;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedEvent} with the given Event details.
+     */
+    @JsonCreator
+    public JsonAdaptedEvent(@JsonProperty("name") String name, @JsonProperty("company") String company,
+                             @JsonProperty("date") String date, @JsonProperty("time") String time,
+                             @JsonProperty("platform") String platform,
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.name = name;
+        this.company = company;
+        this.date = date;
+        this.time = time;
+        this.platform = time;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Event} into this class for Jackson use.
+     */
+    public JsonAdaptedEvent(Event source) {
+        name = source.getName().fullName;
+        company = source.getCompany();
+        date = source.getDate().date;
+        time = source.getTime().time;
+        platform = source.getPlatform().platform;
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted event object into the model's {@code Event} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted event.
+     */
+    public Event toModelType() throws IllegalValueException {
+        final List<Tag> eventTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            eventTags.add(tag.toModelType());
+        }
+
+        //=========================== NAME ==========================================================
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        //=========================== Company ==========================================================
+        if (company == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Company"));
+        }
+        if (company.equals("")) {
+            throw new IllegalValueException("Company name cannot be blank");
+        }
+        final String modelCompany = company;
+
+        //=========================== Date ==========================================================
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modelDate = new Date(date);
+
+        //=========================== Time ==========================================================
+        if (time == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Time.class.getSimpleName()));
+        }
+        if (!Time.isValidTime(time)) {
+            throw new IllegalValueException(Time.MESSAGE_CONSTRAINTS);
+        }
+        final Time modelTime = new Time(time);
+
+        //=========================== Platform ==========================================================
+        if (platform == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Platform.class.getSimpleName()));
+        }
+        if (!Platform.isValidPlatform(platform)) {
+            throw new IllegalValueException(Platform.MESSAGE_CONSTRAINTS);
+        }
+        final Platform modelPlatform = new Platform(platform);
+
+        final Set<Tag> modelTags = new HashSet<>(eventTags);
+        return new Event(modelName, modelCompany, modelDate, modelTime, modelPlatform, modelTags);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 
 /**
@@ -20,15 +21,19 @@ import seedu.address.model.entry.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_EVENT = "Events list contains duplicate event(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedEvent> events = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableAddressBook} with the given persons and events.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("events") List<JsonAdaptedEvent> events) {
         this.persons.addAll(persons);
+        this.events.addAll(events);
     }
 
     /**
@@ -38,6 +43,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        events.addAll(source.getEventList().stream().map(JsonAdaptedEvent::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +59,13 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addPerson(person);
+        }
+        for (JsonAdaptedEvent jsonAdaptedEvent : events) {
+            Event event = jsonAdaptedEvent.toModelType();
+            if (addressBook.hasEvent(event)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_EVENT);
+            }
+            addressBook.addEvent(event);
         }
         return addressBook;
     }


### PR DESCRIPTION
One of the main features of InternBuddy is the ability to manage Events related to a company. 

## An Event has:

- Name of the Event (e.g. Interview)
- Company name related to the event (e.g. Google)
- Date of the Event (e.g. 12-12-2022)
- Time of the Event (e.g 12:30)
- Platform in which the Event is held (e.g. Zoom, on site, Teams)

## Command Format
add_event n/NAME c/COMPANY d/DATE ti/TIME pl/PLATFORM [t/TAG]...
Example: add_event n/Interview c/ABC d/12-12-2022 ti/13:30 pl/zoom t/technical t/coding

## Let's:

- Create the Event class that inherits from Entry class
- Implement `add_event` command to add an Event to the application
- Integrate both the Entry class and `add_event` command to the Logic component
- Integrate both the Entry class and `add_event` command to the Storage component


## Screenshots

Adding new Event
![image](https://user-images.githubusercontent.com/64079065/158212679-73d01aa6-7bec-4527-ae5c-7b315a374032.png)
![image](https://user-images.githubusercontent.com/64079065/158212696-dcae5c1c-6ea6-4bb3-b5a4-e6db3510ac32.png)

Adding the same Event will result in an error message (Handled well)
![image](https://user-images.githubusercontent.com/64079065/158212809-3d68aeb8-d8b7-4a40-af31-535d44231eca.png)

The result will be stored in the `data/addressbook.json` 
![image](https://user-images.githubusercontent.com/64079065/158213065-71445b70-e5f1-4069-97c5-77a7f13fd976.png)

Adding several Events will look like this
<img width="493" alt="image" src="https://user-images.githubusercontent.com/64079065/158213199-88c16d7a-ad86-4914-b8ef-a44bc01b1b54.png">



## There are several things to note:

- Integration of Event class to the UI component of InternBuddy is not yet done
- String validation for Event's company, date, time, and platform attributes is not yet implemented