### PR TITLE
Add Company class and implement AddCompanyCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCompanyCommand.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Company;
+
+/**
+ * Adds a company to the address book.
+ */
+public class AddCompanyCommand extends Command {
+    public static final String COMMAND_WORD = "addc";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a company to the address book. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Shopee "
+            + PREFIX_PHONE + "96613725 "
+            + PREFIX_EMAIL + "askhr@shopee.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_TAG + "ecommerce "
+            + PREFIX_TAG + "hiring";
+
+    public static final String MESSAGE_SUCCESS = "New company added: %1$s";
+    public static final String MESSAGE_DUPLICATE_COMPANY = "This company already exists in the address book";
+
+    private final Company toAdd;
+
+    /**
+     * Creates an AddCompanyCommand to add the specified {@code Company}
+     */
+    public AddCompanyCommand(Company company) {
+        requireNonNull(company);
+        toAdd = company;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasCompany(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_COMPANY);
+        }
+
+        model.addCompany(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddCompanyCommand // instanceof handles nulls
+                && toAdd.equals(((AddCompanyCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCompanyCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddCompanyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.entry.Address;
+import seedu.address.model.entry.Company;
+import seedu.address.model.entry.Email;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input and creates a new AddCompanyCommand object
+ */
+public class AddCompanyCommandParser implements Parser<AddCompanyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCompanyCommand
+     * and returns an AddCompanyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddCompanyCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCompanyCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Company company = new Company(name, phone, email, address, tagList);
+
+        return new AddCompanyCommand(company);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddCompanyCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -46,6 +47,9 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddCompanyCommand.COMMAND_WORD:
+            return new AddCompanyCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Person;
 import seedu.address.model.entry.UniqueEntryList;
 
@@ -15,6 +16,7 @@ import seedu.address.model.entry.UniqueEntryList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueEntryList<Person> persons;
+    private final UniqueEntryList<Company> companies;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -24,7 +26,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      *   among constructors.
      */
     {
-        persons = new UniqueEntryList<Person>();
+        persons = new UniqueEntryList<>();
+        companies = new UniqueEntryList<>();
     }
 
     public AddressBook() {}
@@ -48,6 +51,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the companies list with {@code companies}.
+     * {@code companies} must not contain duplicate companies.
+     */
+    public void setCompanies(List<Company> companies) { this.companies.setEntries(companies); }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
@@ -67,11 +76,27 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a company with the same identity as {@code company} exists in the address book.
+     */
+    public boolean hasCompany(Company company) {
+        requireNonNull(company);
+        return companies.contains(company);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */
     public void addPerson(Person p) {
         persons.add(p);
+    }
+
+    /**
+     * Adds a company to the address book.
+     * The company must not already exist in the address book.
+     */
+    public void addCompany(Company c) {
+        companies.add(c);
     }
 
     /**
@@ -86,6 +111,18 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the given company {@code target} in the list with {@code editedCompany}.
+     * {@code target} must exist in the address book.
+     * The company identity of {@code editedCompany} must not be the same as another existing company in the
+     * address book.
+     */
+    public void setCompany(Company target, Company editedCompany) {
+        requireNonNull(editedCompany);
+
+        companies.setEntry(target, editedCompany);
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
@@ -93,11 +130,20 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeCompany(Company key) {
+        companies.remove(key);
+    }
+
     //// util methods
 
     @Override
     public String toString() {
-        return persons.asUnmodifiableObservableList().size() + " persons";
+        return persons.asUnmodifiableObservableList().size() + " persons,"
+                + companies.asUnmodifiableObservableList().size() + " companies";
         // TODO: refine later
     }
 
@@ -107,14 +153,27 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Company> getCompanyList() {
+        return companies.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddressBook)) {
+            return false;
+        }
+
+        AddressBook otherAddressBook = (AddressBook) other;
+        return persons.equals(otherAddressBook.persons)
+                && companies.equals(otherAddressBook.companies);
     }
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return persons.hashCode() + companies.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Person;
 
 /**
@@ -13,6 +14,7 @@ import seedu.address.model.entry.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Company> PREDICATE_SHOW_ALL_COMPANIES = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -84,4 +86,38 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns true if a company with the same identity as {@code person} exists in the address book.
+     */
+    boolean hasCompany(Company company);
+
+    /**
+     * Deletes the given company.
+     * The person must exist in the address book.
+     */
+    void deleteCompany(Company target);
+
+    /**
+     * Adds the given company.
+     * {@code company} must not already exist in the address book.
+     */
+    void addCompany(Company company);
+
+    /**
+     * Replaces the given company {@code target} with {@code editedCompany}.
+     * {@code target} must exist in the address book.
+     * The company identity of {@code editedCompany} must not be the same as another existing company
+     * in the address book.
+     */
+    void setCompany(Company target, Company editedCompany);
+
+    /** Returns an unmodifiable view of the filtered company list */
+    ObservableList<Company> getFilteredCompanyList();
+
+    /**
+     * Updates the filter of the filtered company list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredCompanyList(Predicate<Company> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Person;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Company> filteredCompanies;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredCompanies = new FilteredList<>(this.addressBook.getCompanyList());
     }
 
     public ModelManager() {
@@ -87,6 +90,8 @@ public class ModelManager implements Model {
         return addressBook;
     }
 
+    //========== Person List Modifiers ========================================================================
+
     @Override
     public boolean hasPerson(Person person) {
         requireNonNull(person);
@@ -111,6 +116,37 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    //========== Company List Modifiers ======================================================================
+
+    @Override
+    public boolean hasCompany(Company company) {
+        requireNonNull(company);
+        return addressBook.hasCompany(company);
+    }
+
+    @Override
+    public void deleteCompany(Company target) {
+        addressBook.removeCompany(target);
+    }
+
+    @Override
+    public void addCompany(Company company) {
+        addressBook.addCompany(company);
+        updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
+    }
+
+    /**
+     * Replaces the given company {@code target} with {@code editedCompany}.
+     * {@code target} must exist in the address book.
+     * The company identity of {@code editedCompany} must not be the same as another existing company
+     * in the address book.
+     */
+    public void setCompany(Company target, Company editedCompany) {
+        requireAllNonNull(target, editedCompany);
+
+        addressBook.setCompany(target, editedCompany);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -127,6 +163,26 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
     }
+
+    //=========== Filtered Company List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the filtered company list
+     */
+    @Override
+    public ObservableList<Company> getFilteredCompanyList() {
+        return filteredCompanies;
+    }
+
+    /**
+     * Updates the filter of the filtered company list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    public void updateFilteredCompanyList(Predicate<Company> predicate) {
+        requireNonNull(predicate);
+        filteredCompanies.setPredicate(predicate);
+    }
+
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Person;
 
 /**
@@ -13,5 +14,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Returns an unmodifiable view of the companies list.
+     * This list will not contain any duplicate companies.
+     */
+    ObservableList<Company> getCompanyList();
 
 }

--- a/src/main/java/seedu/address/model/entry/Company.java
+++ b/src/main/java/seedu/address/model/entry/Company.java
@@ -1,0 +1,106 @@
+package seedu.address.model.entry;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.address.model.tag.Tag;
+
+public class Company extends Entry {
+
+    // Identity fields
+    private final Phone phone;
+    private final Email email;
+
+    // Data fields
+    private final Address address;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Company(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+        super(name, tags);
+        requireAllNonNull(phone, email, address);
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+    }
+
+    public Phone getPhone() {
+        return phone;
+    }
+
+    public Email getEmail() {
+        return email;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    /**
+     * Returns true if both entries are a company and have the same name.
+     * This defines a weaker notion of equality between two persons.
+     */
+    public boolean isSameEntry(Entry otherEntry) {
+        if (otherEntry == this) {
+            return true;
+        }
+
+        if (!(otherEntry instanceof Company)) {
+            return false;
+        }
+
+        return otherEntry.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if both persons have the same identity and data fields.
+     * This defines a stronger notion of equality between two persons.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Company)) {
+            return false;
+        }
+
+        Company otherPerson = (Company) other;
+        return otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getEmail().equals(getEmail())
+                && otherPerson.getAddress().equals(getAddress())
+                && otherPerson.getTags().equals(getTags());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(getName(), phone, email, address, getTags());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append("; Phone: ")
+                .append(getPhone())
+                .append("; Email: ")
+                .append(getEmail())
+                .append("; Address: ")
+                .append(getAddress());
+
+        Set<Tag> tags = getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
@@ -1,0 +1,104 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.Address;
+import seedu.address.model.entry.Company;
+import seedu.address.model.entry.Email;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Phone;
+import seedu.address.model.tag.Tag;
+
+public class JsonAdaptedCompany {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Company's %s field is missing!";
+
+    private final String name;
+    private final String phone;
+    private final String email;
+    private final String address;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedPerson} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedCompany(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Company} into this class for Jackson use.
+     */
+    public JsonAdaptedCompany(Company source) {
+        name = source.getName().fullName;
+        phone = source.getPhone().value;
+        email = source.getEmail().value;
+        address = source.getAddress().value;
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted company object into the model's {@code Company} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted company.
+     */
+    public Company toModelType() throws IllegalValueException {
+        final List<Tag> companyTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            companyTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+        if (!Phone.isValidPhone(phone)) {
+            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
+        }
+        final Phone modelPhone = new Phone(phone);
+
+        if (email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
+        }
+        if (!Email.isValidEmail(email)) {
+            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        }
+        final Email modelEmail = new Email(email);
+
+        if (address == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
+        if (!Address.isValidAddress(address)) {
+            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        }
+        final Address modelAddress = new Address(address);
+
+        final Set<Tag> modelTags = new HashSet<>(companyTags);
+        return new Company(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Person;
 
 /**
@@ -22,13 +23,16 @@ class JsonSerializableAddressBook {
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedCompany> companies = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableAddressBook} with the given persons and companies.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("companies") List<JsonAdaptedCompany> companies) {
         this.persons.addAll(persons);
+        this.companies.addAll(companies);
     }
 
     /**
@@ -38,6 +42,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        companies.addAll(source.getCompanyList().stream().map(JsonAdaptedCompany::new).collect(Collectors.toList()));
     }
 
     /**
@@ -47,6 +52,7 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
+
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();
             if (addressBook.hasPerson(person)) {
@@ -54,6 +60,15 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPerson(person);
         }
+
+        for (JsonAdaptedCompany jsonAdaptedCompany : companies) {
+            Company company = jsonAdaptedCompany.toModelType();
+            if (!addressBook.hasCompany(company)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+            }
+            addressBook.addCompany(company);
+        }
+
         return addressBook;
     }
 

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -9,5 +9,6 @@
     "phone": "948asdf2424",
     "email": "hans@example.com",
     "address": "4th street"
-  } ]
+  } ],
+  "companies": []
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -4,5 +4,6 @@
     "phone": "9482424",
     "email": "hans@example.com",
     "address": "4th street"
-  } ]
+  } ],
+  "companies": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -10,5 +10,6 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street"
-  } ]
+  } ],
+  "companies": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -4,5 +4,6 @@
     "phone": "9482424",
     "email": "invalid@email!3e",
     "address": "4th street"
-  } ]
+  } ],
+  "companies": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -42,5 +42,6 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "tagged" : [ ]
-  } ]
+  } ],
+  "companies": []
 }


### PR DESCRIPTION
Fixes #23 

### Company Class

Companies are one of the 3 types of entries in InternBuddy.

At the moment, Companies have the same attributes as the Person class. This was done instead of creating a parent class that both Company and Person inherit from because the two may have differing attributes in the future.

### Add Company Command

This command adds a company to the company list.

Format: addc n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...
Example: addc n/Shopee p/96613725 e/askhr@shopee.com a/311, Clementi Ave 2, #02-25 t/ecommerce t/hiring

### Changes Made

Let's:

* create a `Company` class that inherits from `Entry`
* add a `UniqueEntryList` of `Company` to `AddressBook`
* add operations to modify and access the company list in `AddressBook` and `ModelManager`
* update `JsonSerializableAddressBook` to store the company list as well
* add `AddCompanyCommand` and `AddCompanyCommandParser` to handle Add Company commands
* update `AddressBookParser` to handle Add Company commands
* update some test data json files