### PR TITLE
Add delete company command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,4 +11,5 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
+    public static final String MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX = "The company index provided is invalid";
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCompanyCommand.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Company;
+import seedu.address.model.entry.Person;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Deletes a company identified using it's displayed index from the address book.
+ */
+public class DeleteCompanyCommand extends Command {
+
+    public static final String COMMAND_WORD = "delete_company";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the company identified by the index number used in the displayed company list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_COMPANY_SUCCESS = "Deleted Company: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteCompanyCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Company> lastShownList = model.getFilteredCompanyList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+        }
+
+        Company companyToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteCompany(companyToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_COMPANY_SUCCESS, companyToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteCompanyCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteCompanyCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCompanyCommand.java
@@ -1,15 +1,14 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Company;
-import seedu.address.model.entry.Person;
-
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Deletes a company identified using it's displayed index from the address book.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteCompanyCommand;
 import seedu.address.logic.commands.DeleteEventCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -62,6 +63,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteCompanyCommand.COMMAND_WORD:
+            return new DeleteCompanyCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCompanyCommandParser.java
@@ -1,11 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCompanyCommand;
-import seedu.address.logic.commands.DeleteEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new DeleteCompanyCommand object

--- a/src/main/java/seedu/address/logic/parser/DeleteCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCompanyCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteCompanyCommand;
+import seedu.address.logic.commands.DeleteEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new DeleteCompanyCommand object
+ */
+public class DeleteCompanyCommandParser implements Parser<DeleteCompanyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteEventCommand
+     * and returns a DeleteEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteCompanyCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteCompanyCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCompanyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}


### PR DESCRIPTION
The core feature of InternBuddy includes CRUD operations of company entries.

Let's add a command to delete an existing company entry

## Screenshots
An existing company entry is shown by the list company command
![Screenshot_20220317_195820](https://user-images.githubusercontent.com/36869318/158804263-bdc0a747-b5e7-4937-b08d-eafb3cf0052e.png)

The shown entry has been deleted by the new delete company command
![Screenshot_20220317_195849](https://user-images.githubusercontent.com/36869318/158804365-9cd8371a-8619-48a1-a49b-702e8c25f3ca.png)