### PR TITLE
Create find event by company

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX = "The entry index provided is invalid";
+    public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d events listed!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_NONEXISTENT_COMPANY = "The company provided does not exist in the company list";
 }

--- a/src/main/java/seedu/address/logic/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEventCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.entry.CompanyNameContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all events in address book whose companyName contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindEventCommand extends Command {
+
+    public static final String COMMAND_WORD = "finde";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all events whose companyName contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " shopee";
+
+    private final CompanyNameContainsKeywordsPredicate predicate;
+
+    public FindEventCommand(CompanyNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEventList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EVENTS_LISTED_OVERVIEW, model.getFilteredEventList().size()),
+                false, false, false, false, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindEventCommand // instanceof handles nulls
+                && predicate.equals(((FindEventCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindEventCommand;
 import seedu.address.logic.commands.FindPersonCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCompanyCommand;
@@ -65,6 +66,9 @@ public class AddressBookParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case FindEventCommand.COMMAND_WORD:
+            return new FindEventCommandParser().parse(arguments);
 
         case FindPersonCommand.COMMAND_WORD:
             return new FindPersonCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.entry.CompanyNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindCompanyPersonCommand object
+ */
+public class FindEventCommandParser implements Parser<FindEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindEventCommand
+     * and returns a FindEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindEventCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindEventCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindEventCommand(new CompanyNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -46,8 +46,8 @@ public class ModelManager implements Model {
 
         currentlyDisplayedListType = ListType.PERSON;
 
-        // Don't allow deleting/finding/editing on the companies or events list at the beginning
-        filteredCompanies.setPredicate(PREDICATE_SHOW_NO_COMPANIES);
+        // Don't allow deleting/finding/editing on the events or person list at the beginning
+        filteredPersons.setPredicate(PREDICATE_SHOW_NO_PERSONS);
         filteredEvents.setPredicate(PREDICATE_SHOW_NO_EVENTS);
     }
 

--- a/src/main/java/seedu/address/model/entry/CompanyNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/entry/CompanyNameContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.entry;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Event}'s  {@code companyName} matches any of the keywords given.
+ */
+public class CompanyNameContainsKeywordsPredicate implements Predicate<Event> {
+    private final List<String> keywords;
+
+    public CompanyNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Event event) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(event.getCompanyName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CompanyNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((CompanyNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,10 +6,7 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.entry.Email;
-import seedu.address.model.entry.Name;
-import seedu.address.model.entry.Person;
-import seedu.address.model.entry.Phone;
+import seedu.address.model.entry.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -19,17 +16,41 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Name("ABCDE"), new Phone("87438807"),
-                    new Email("alexyeoh@example.com"), getTagSet("friends")),
+                    new Email("alexyeoh@example.com"), getTagSet("hr")),
             new Person(new Name("Bernice Yu"), new Name("DBSSS"), new Phone("99272758"),
-                    new Email("berniceyu@example.com"), getTagSet("colleagues", "friends")),
+                    new Email("berniceyu@example.com"), getTagSet("senior")),
             new Person(new Name("Charlotte Oliveiro"), new Name("SGShop"), new Phone("93210283"),
-                    new Email("charlotte@example.com"), getTagSet("neighbours")),
+                    new Email("charlotte@example.com"), getTagSet("hr")),
             new Person(new Name("David Li"), new Name("ABCDE"), new Phone("91031282"),
-                    new Email("lidavid@example.com"), getTagSet("family")),
+                    new Email("lidavid@example.com"), getTagSet("hr")),
             new Person(new Name("Irfan Ibrahim"), new Name("SGShop"), new Phone("92492021"),
-                    new Email("irfan@example.com"), getTagSet("classmates")),
+                    new Email("irfan@example.com"), getTagSet("senior")),
             new Person(new Name("Roy Balakrishnan"), new Name("DBSSS"), new Phone("92624417"),
-                    new Email("royb@example.com"), getTagSet("colleagues"))
+                    new Email("royb@example.com"), getTagSet("hr"))
+        };
+    }
+
+    public static Company[] getSampleCompanies() {
+        return new Company[] {
+                new Company(new Name("ABCDE"), new Phone("12345678"), new Email("hr@ABCDE.com"),
+                        new Address("123 Street Singapore"), getTagSet("OA")),
+                new Company(new Name("DBSSS"), new Phone("23859694"), new Email("hr@DBSSS.com"),
+                        new Address("456 Street Singapore"), getTagSet("interview")),
+                new Company(new Name("SGShop"), new Phone("58496034"), new Email("hr@SGShop.com"),
+                        new Address("789 Street Singapore"), getTagSet("applied"))
+        };
+    }
+
+    public static Event[] getSampleEvents() {
+        return new Event[] {
+                new Event(new Name("Interview"), new Name("SGShop"), new Date("16-9-2022"), new Time("13:30"),
+                        new Location("zoom"), getTagSet("technical")),
+                new Event(new Name("Interview"), new Name("DBSSS"), new Date("13-10-2022"), new Time("12:30"),
+                        new Location("zoom"), getTagSet("behavioural")),
+                new Event(new Name("Online Assessment"), new Name("DBSSS"), new Date("23-04-2022"), new Time("14:30"),
+                        new Location("hackerrank"), getTagSet("OOP")),
+                new Event(new Name("Online Assessment"), new Name("SGShop"), new Date("16-05-2022"), new Time("15:30"),
+                        new Location("hackereartch"), getTagSet("datastructure")),
         };
     }
 
@@ -37,6 +58,12 @@ public class SampleDataUtil {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
+        }
+        for (Company sampleCompany : getSampleCompanies()) {
+            sampleAb.addCompany(sampleCompany);
+        }
+        for (Event sampleEvent : getSampleEvents()) {
+            sampleAb.addEvent(sampleEvent);
         }
         return sampleAb;
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -116,7 +116,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         companyListPanel = new CompanyListPanel(logic.getFilteredCompanyList());
         eventListPanel = new EventListPanel(logic.getFilteredEventList());
-        entryListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        entryListPanelPlaceholder.getChildren().add(companyListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());


### PR DESCRIPTION
## Background
### User Stories 
As a user keeping track of events from many different companies, I can find events related to a certain company

### Reason of addition
To improve user experience, we add more features to ease users to filter the events list. In this case, finding specific events related to a particular companyName. 

### Reason of Changes
As the focus of the application is to manage companies, therefore the default display should be the company list


## Let's
- Create Find Event based on companyName
- Change default display to company list