### PR TITLE
Edit company command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,4 +12,5 @@ public class Messages {
     public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d events listed!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_NONEXISTENT_COMPANY = "The company provided does not exist in the company list";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 }

--- a/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
@@ -1,13 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_NONEXISTENT_COMPANY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,89 +19,86 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.entry.Address;
+import seedu.address.model.entry.Company;
 import seedu.address.model.entry.Email;
 import seedu.address.model.entry.Name;
-import seedu.address.model.entry.Person;
 import seedu.address.model.entry.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditPersonCommand extends Command {
+public class EditCompanyCommand extends Command {
 
-    public static final String COMMAND_WORD = "editp";
+    public static final String COMMAND_WORD = "editc";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the command identified "
+            + "by the index number used in the displayed company list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_COMPANY + "COMPANY] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_EDIT_COMPANY_SUCCESS = "Edited Company: %1$s";
+    public static final String MESSAGE_DUPLICATE_COMPANY = "This company already exists in the address book.";
 
     private final Index index;
-    private final EditPersonDescriptor editPersonDescriptor;
+    private final EditCompanyDescriptor editCompanyDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * @param index of the person in the filtered company list to edit
+     * @param editCompanyDescriptor details to edit the person with
      */
-    public EditPersonCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditCompanyCommand(Index index, EditCompanyDescriptor editCompanyDescriptor) {
         requireNonNull(index);
-        requireNonNull(editPersonDescriptor);
+        requireNonNull(editCompanyDescriptor);
 
         this.index = index;
-        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+        this.editCompanyDescriptor = new EditCompanyDescriptor(editCompanyDescriptor);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Company> lastShownList = model.getFilteredCompanyList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
         }
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        Company companyToEdit = lastShownList.get(index.getZeroBased());
+        Company editedCompany = createEditedCompany(companyToEdit, editCompanyDescriptor);
 
-        if (!personToEdit.isSameEntry(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        if (!companyToEdit.isSameEntry(editedCompany) && model.hasCompany(editedCompany)) {
+            throw new CommandException(MESSAGE_DUPLICATE_COMPANY);
         }
 
-        if (!model.hasCompany(editedPerson.getCompanyName())) {
-            throw new CommandException(MESSAGE_NONEXISTENT_COMPANY);
-        }
-
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+        model.setCompany(companyToEdit, editedCompany);
+        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
+        return new CommandResult(String.format(MESSAGE_EDIT_COMPANY_SUCCESS, editedCompany));
     }
 
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
-        assert personToEdit != null;
+    private static Company createEditedCompany(Company companyToEdit, EditCompanyDescriptor editCompanyDescriptor) {
+        assert companyToEdit != null;
 
-        Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        Name updatedCompanyName = editPersonDescriptor.getCompanyName().orElse(personToEdit.getCompanyName());
-        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Name updatedName = editCompanyDescriptor.getName().orElse(companyToEdit.getName());
+        Phone updatedPhone = editCompanyDescriptor.getPhone().orElse(companyToEdit.getPhone());
+        Email updatedEmail = editCompanyDescriptor.getEmail().orElse(companyToEdit.getEmail());
+        Address updatedAddress = editCompanyDescriptor.getAddress().orElse(companyToEdit.getAddress());
+        Set<Tag> updatedTags = editCompanyDescriptor.getTags().orElse(companyToEdit.getTags());
 
-        return new Person(updatedName, updatedCompanyName, updatedPhone, updatedEmail, updatedTags);
+        return new Company(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
     }
 
     @Override
@@ -113,46 +109,46 @@ public class EditPersonCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditPersonCommand)) {
+        if (!(other instanceof EditCompanyCommand)) {
             return false;
         }
 
         // state check
-        EditPersonCommand e = (EditPersonCommand) other;
+        EditCompanyCommand e = (EditCompanyCommand) other;
         return index.equals(e.index)
-                && editPersonDescriptor.equals(e.editPersonDescriptor);
+                && editCompanyDescriptor.equals(e.editCompanyDescriptor);
     }
 
     /**
      * Stores the details to edit the person with. Each non-empty field value will replace the
      * corresponding field value of the person.
      */
-    public static class EditPersonDescriptor {
+    public static class EditCompanyDescriptor {
         private Name name;
-        private Name companyName;
         private Phone phone;
         private Email email;
+        private Address address;
         private Set<Tag> tags;
 
-        public EditPersonDescriptor() {}
+        public EditCompanyDescriptor() {}
 
         /**
          * Copy constructor.
          * A defensive copy of {@code tags} is used internally.
          */
-        public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+        public EditCompanyDescriptor(EditCompanyDescriptor toCopy) {
             setName(toCopy.name);
-            setCompanyName(toCopy.companyName);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setTags(toCopy.tags);
+            setAddress(toCopy.address);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, companyName, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
         }
 
         public void setName(Name name) {
@@ -179,12 +175,12 @@ public class EditPersonCommand extends Command {
             return Optional.ofNullable(email);
         }
 
-        public void setCompanyName(Name companyName) {
-            this.companyName = companyName;
+        public void setAddress(Address address) {
+            this.address = address;
         }
 
-        public Optional<Name> getCompanyName() {
-            return Optional.ofNullable(companyName);
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
         }
 
         /**
@@ -212,17 +208,17 @@ public class EditPersonCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditPersonDescriptor)) {
+            if (!(other instanceof EditCompanyDescriptor)) {
                 return false;
             }
 
             // state check
-            EditPersonDescriptor e = (EditPersonDescriptor) other;
+            EditCompanyDescriptor e = (EditCompanyDescriptor) other;
 
             return getName().equals(e.getName())
-                    && getCompanyName().equals(e.getCompanyName())
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
@@ -82,6 +82,12 @@ public class EditCompanyCommand extends Command {
 
         model.setCompany(companyToEdit, editedCompany);
         model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
+
+        if (!companyToEdit.getName().equals(editedCompany.getName())) {
+            model.getAddressBook().updateCompanyNames(
+                    companyToEdit.getName().toString(), editedCompany.getName().toString());
+        }
+
         return new CommandResult(String.format(MESSAGE_EDIT_COMPANY_SUCCESS, editedCompany));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCompanyCommand.java
@@ -27,7 +27,7 @@ import seedu.address.model.entry.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing company in the address book.
  */
 public class EditCompanyCommand extends Command {
 
@@ -53,8 +53,8 @@ public class EditCompanyCommand extends Command {
     private final EditCompanyDescriptor editCompanyDescriptor;
 
     /**
-     * @param index of the person in the filtered company list to edit
-     * @param editCompanyDescriptor details to edit the person with
+     * @param index of the company in the filtered company list to edit
+     * @param editCompanyDescriptor details to edit the company with
      */
     public EditCompanyCommand(Index index, EditCompanyDescriptor editCompanyDescriptor) {
         requireNonNull(index);
@@ -92,8 +92,8 @@ public class EditCompanyCommand extends Command {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Company} with the details of {@code companyToEdit}
+     * edited with {@code editCompanyDescriptor}.
      */
     private static Company createEditedCompany(Company companyToEdit, EditCompanyDescriptor editCompanyDescriptor) {
         assert companyToEdit != null;
@@ -126,8 +126,8 @@ public class EditCompanyCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will replace the
-     * corresponding field value of the person.
+     * Stores the details to edit the company with. Each non-empty field value will replace the
+     * corresponding field value of the company.
      */
     public static class EditCompanyDescriptor {
         private Name name;

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -1,0 +1,237 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EVENTS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Date;
+import seedu.address.model.entry.Event;
+import seedu.address.model.entry.Location;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Time;
+import seedu.address.model.tag.Tag;
+
+public class EditEventCommand extends Command {
+    public static final String COMMAND_WORD = "edite";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the event identified "
+            + "by the index number used in the displayed event list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_COMPANY + "COMPANY] "
+            + "[" + PREFIX_DATE + "DATE] "
+            + "[" + PREFIX_TIME + "TIME] "
+            + "[" + PREFIX_LOCATION + "TIME] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_DATE + "2022-04-12 "
+            + PREFIX_TIME + "12:20";
+
+    public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book.";
+
+    private final Index index;
+    private final EditEventCommand.EditEventDescriptor editEventDescriptor;
+
+    /**
+     * @param index of the event in the filtered event list to edit
+     * @param editEventDescriptor details to edit the event with
+     */
+    public EditEventCommand(Index index, EditEventCommand.EditEventDescriptor editEventDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editEventDescriptor);
+
+        this.index = index;
+        this.editEventDescriptor = new EditEventCommand.EditEventDescriptor(editEventDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Event> lastShownList = model.getFilteredEventList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+        }
+
+        Event eventToEdit = lastShownList.get(index.getZeroBased());
+        Event editedEvent = createEditedEvent(eventToEdit, editEventDescriptor);
+
+        if (!eventToEdit.isSameEntry(editedEvent) && model.hasEvent(editedEvent)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        }
+
+        model.setEvent(eventToEdit, editedEvent);
+        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
+        return new CommandResult(String.format(MESSAGE_EDIT_EVENT_SUCCESS, editedEvent));
+    }
+
+    /**
+     * Creates and returns a {@code Event} with the details of {@code eventToEdit}
+     * edited with {@code editEventDescriptor}.
+     */
+    private static Event createEditedEvent(Event eventToEdit, EditEventDescriptor editEventDescriptor) {
+        assert eventToEdit != null;
+
+        Name updatedName = editEventDescriptor.getName().orElse(eventToEdit.getName());
+        Name updatedCompanyName = editEventDescriptor.getCompanyName().orElse(eventToEdit.getCompanyName());
+        Date updatedDate = editEventDescriptor.getDate().orElse(eventToEdit.getDate());
+        Time updatedTime = editEventDescriptor.getTime().orElse(eventToEdit.getTime());
+        Location updatedLocation = editEventDescriptor.getLocation().orElse(eventToEdit.getLocation());
+        Set<Tag> updatedTags = editEventDescriptor.getTags().orElse(eventToEdit.getTags());
+
+        return new Event(updatedName, updatedCompanyName, updatedDate, updatedTime, updatedLocation, updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditEventCommand)) {
+            return false;
+        }
+
+        // state check
+        EditEventCommand e = (EditEventCommand) other;
+        return index.equals(e.index)
+                && editEventDescriptor.equals(e.editEventDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the event with. Each non-empty field value will replace the
+     * corresponding field value of the event.
+     */
+    public static class EditEventDescriptor {
+        private Name name;
+        private Name companyName;
+        private Date date;
+        private Time time;
+        private Location location;
+        private Set<Tag> tags;
+
+        public EditEventDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditEventDescriptor(EditEventCommand.EditEventDescriptor toCopy) {
+            setName(toCopy.name);
+            setCompanyName(toCopy.companyName);
+            setDate(toCopy.date);
+            setTime(toCopy.time);
+            setLocation(toCopy.location);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, companyName, date, time, location, tags);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setCompanyName(Name companyName) {
+            this.companyName = companyName;
+        }
+
+        public Optional<Name> getCompanyName() {
+            return Optional.ofNullable(companyName);
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public Optional<Date> getDate() {
+            return Optional.ofNullable(date);
+        }
+
+        public void setTime(Time time) {
+            this.time = time;
+        }
+
+        public Optional<Time> getTime() {
+            return Optional.ofNullable(time);
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+
+        public Optional<Location> getLocation() {
+            return Optional.ofNullable(location);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditEventCommand.EditEventDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditEventCommand.EditEventDescriptor e = (EditEventCommand.EditEventDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getCompanyName().equals(e.getCompanyName())
+                    && getDate().equals(e.getDate())
+                    && getTime().equals(e.getTime())
+                    && getLocation().equals(e.getLocation())
+                    && getTags().equals(e.getTags());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NONEXISTENT_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -66,6 +67,7 @@ public class EditEventCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         List<Event> lastShownList = model.getFilteredEventList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -77,6 +79,10 @@ public class EditEventCommand extends Command {
 
         if (!eventToEdit.isSameEntry(editedEvent) && model.hasEvent(editedEvent)) {
             throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        }
+
+        if (!model.hasCompany(editedEvent.getCompanyName())) {
+            throw new CommandException(MESSAGE_NONEXISTENT_COMPANY);
         }
 
         model.setEvent(eventToEdit, editedEvent);

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -46,7 +46,6 @@ public class EditEventCommand extends Command {
             + PREFIX_TIME + "12:20";
 
     public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book.";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -28,6 +28,9 @@ import seedu.address.model.entry.Name;
 import seedu.address.model.entry.Time;
 import seedu.address.model.tag.Tag;
 
+/**
+ * Edits the details of an existing event in the address book.
+ */
 public class EditEventCommand extends Command {
     public static final String COMMAND_WORD = "edite";
 
@@ -39,7 +42,7 @@ public class EditEventCommand extends Command {
             + "[" + PREFIX_COMPANY + "COMPANY] "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_TIME + "TIME] "
-            + "[" + PREFIX_LOCATION + "TIME] "
+            + "[" + PREFIX_LOCATION + "LOCATION] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_DATE + "2022-04-12 "

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NONEXISTENT_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -78,6 +79,10 @@ public class EditPersonCommand extends Command {
 
         if (!personToEdit.isSameEntry(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        if (!model.hasCompany(editedPerson.getCompanyName())) {
+            throw new CommandException(MESSAGE_NONEXISTENT_COMPANY);
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCompanyCommand;
 import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -60,11 +61,14 @@ public class AddressBookParser {
         case AddEventCommand.COMMAND_WORD:
             return new AddEventCommandParser().parse(arguments);
 
-        case EditEventCommand.COMMAND_WORD:
-            return new EditEventCommandParser().parse(arguments);
-
         case EditPersonCommand.COMMAND_WORD:
             return new EditPersonCommandParser().parse(arguments);
+
+        case EditCompanyCommand.COMMAND_WORD:
+            return new EditCompanyCommandParser().parse(arguments);
+
+        case EditEventCommand.COMMAND_WORD:
+            return new EditEventCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCompanyCommand;
@@ -58,6 +59,9 @@ public class AddressBookParser {
 
         case AddEventCommand.COMMAND_WORD:
             return new AddEventCommandParser().parse(arguments);
+
+        case EditEventCommand.COMMAND_WORD:
+            return new EditEventCommandParser().parse(arguments);
 
         case EditPersonCommand.COMMAND_WORD:
             return new EditPersonCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCompanyCommandParser.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_EDITED;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCompanyCommand;
+import seedu.address.logic.commands.EditCompanyCommand.EditCompanyDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditEventCommand object
+ */
+public class EditCompanyCommandParser implements Parser<EditCompanyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditEventCommand
+     * and returns an EditEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditCompanyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_ADDRESS, PREFIX_TAG);
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCompanyCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditCompanyDescriptor editCompanyDescriptor = new EditCompanyDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editCompanyDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            editCompanyDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            editCompanyDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            editCompanyDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        ParserUtil.parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editCompanyDescriptor::setTags);
+
+        if (!editCompanyDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCompanyCommand(index, editCompanyDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCompanyCommandParser.java
@@ -15,13 +15,13 @@ import seedu.address.logic.commands.EditCompanyCommand.EditCompanyDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new EditEventCommand object
+ * Parses input arguments and creates a new EditCompanyCommand object
  */
 public class EditCompanyCommandParser implements Parser<EditCompanyCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditEventCommand
-     * and returns an EditEventCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the EditCompanyCommand
+     * and returns an EditCompanyCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCompanyCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditEventCommand;
+import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new EditEventCommand object
+ */
+public class EditEventCommandParser implements Parser<EditEventCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditEventCommand
+     * and returns an EditEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COMPANY,
+                        PREFIX_DATE, PREFIX_TIME, PREFIX_LOCATION, PREFIX_TAG);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditEventCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditEventDescriptor editEventDescriptor = new EditEventDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editEventDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
+            editEventDescriptor.setCompanyName(ParserUtil.parseCompanyName(
+                    argMultimap.getValue(PREFIX_COMPANY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editEventDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TIME).isPresent()) {
+            editEventDescriptor.setTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
+            editEventDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
+        }
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editEventDescriptor::setTags);
+
+        if (!editEventDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditEventCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditEventCommand(index, editEventDescriptor);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_EDITED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -9,16 +10,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditEventCommand;
 import seedu.address.logic.commands.EditEventCommand.EditEventDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditEventCommand object
@@ -62,28 +57,12 @@ public class EditEventCommandParser implements Parser<EditEventCommand> {
         if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
             editEventDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editEventDescriptor::setTags);
+        ParserUtil.parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editEventDescriptor::setTags);
 
         if (!editEventDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditEventCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(MESSAGE_NOT_EDITED);
         }
 
         return new EditEventCommand(index, editEventDescriptor);
     }
-
-    /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
-     */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
-        assert tags != null;
-
-        if (tags.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
@@ -2,22 +2,17 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_EDITED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.EditPersonCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditPersonCommand object
@@ -57,28 +52,13 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        ParserUtil.parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditPersonCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(MESSAGE_NOT_EDITED);
         }
 
         return new EditPersonCommand(index, editPersonDescriptor);
-    }
-
-    /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
-     */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
-        assert tags != null;
-
-        if (tags.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,7 +3,9 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -123,6 +125,21 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    public static Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -193,18 +193,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Event> getEventList() {
-        return events.asUnmodifiableObservableList();
+    public void updateCompanyNames(String oldName, String newName) {
+        persons.updateCompanyNames(oldName, newName);
+        events.updateCompanyNames(oldName, newName);
     }
 
-    //// util methods
-
     @Override
-    public String toString() {
-        return persons.asUnmodifiableObservableList().size() + " persons,"
-                + companies.asUnmodifiableObservableList().size() + " companies, "
-                + events.asUnmodifiableObservableList().size() + " events";
-        // TODO: refine later
+    public ObservableList<Event> getEventList() {
+        return events.asUnmodifiableObservableList();
     }
 
     @Override
@@ -215,6 +211,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Company> getCompanyList() {
         return companies.asUnmodifiableObservableList();
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return persons.asUnmodifiableObservableList().size() + " persons,"
+                + companies.asUnmodifiableObservableList().size() + " companies, "
+                + events.asUnmodifiableObservableList().size() + " events";
+        // TODO: refine later
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -11,6 +11,12 @@ import seedu.address.model.entry.Person;
 public interface ReadOnlyAddressBook {
 
     /**
+     * Updates the companyName of all persons and events whose companyName has the same name as {@code oldName} to be
+     * {@code newName} instead.
+     */
+    void updateCompanyNames(String oldName, String newName);
+
+    /**
      * Returns an unmodifiable view of the persons list.
      * This list will not contain any duplicate persons.
      */
@@ -22,6 +28,10 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Company> getCompanyList();
 
+    /**
+     * Returns an unmodifiable view of the events list.
+     * This list will not contain any duplicate events.
+     */
     ObservableList<Event> getEventList();
 
 }

--- a/src/main/java/seedu/address/model/entry/Company.java
+++ b/src/main/java/seedu/address/model/entry/Company.java
@@ -69,6 +69,11 @@ public class Company extends Entry {
         return otherEntry.getName().equals(getName());
     }
 
+    @Override
+    public void updateCompanyName(String oldName, String newName) {
+        return;
+    }
+
     /**
      * Returns true if both companies have the same identity and data fields.
      * This defines a stronger notion of equality between two companies.
@@ -115,5 +120,4 @@ public class Company extends Entry {
         }
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/entry/Entry.java
+++ b/src/main/java/seedu/address/model/entry/Entry.java
@@ -41,5 +41,10 @@ public abstract class Entry {
      */
     public abstract boolean isSameEntry(Entry otherEntry);
 
-
+    /**
+     * If the companyName of the entry matches {@code oldName}, then it is
+     * changed to {@code newName}.
+     * Note: This only applies for Person and Event. Company does not have any defined functionality for this.
+     */
+    public abstract void updateCompanyName(String oldName, String newName);
 }

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -14,7 +14,7 @@ import seedu.address.model.tag.Tag;
 public class Event extends Entry {
 
     //Identity fields
-    private final Name companyName;
+    private Name companyName;
 
     // Data fields
     private final Date date;
@@ -68,6 +68,13 @@ public class Event extends Entry {
                 && otherEvent.getCompanyName().equals(getCompanyName())
                 && otherEvent.getDate().equals(getDate())
                 && otherEvent.getTime().equals(getTime());
+    }
+
+    @Override
+    public void updateCompanyName(String oldName, String newName) {
+        if (oldName.equals(this.companyName.toString())) {
+            this.companyName = new Name(newName);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/entry/Person.java
+++ b/src/main/java/seedu/address/model/entry/Person.java
@@ -18,7 +18,7 @@ public class Person extends Entry {
     private final Email email;
 
     // Data fields
-    private final Name companyName;
+    private Name companyName;
 
     /**
      * Every field must be present and not null.
@@ -57,6 +57,13 @@ public class Person extends Entry {
         }
 
         return otherEntry.getName().equals(getName());
+    }
+
+    @Override
+    public void updateCompanyName(String oldName, String newName) {
+        if (oldName.equals(this.companyName.toString())) {
+            this.companyName = new Name(newName);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/entry/UniqueEntryList.java
+++ b/src/main/java/seedu/address/model/entry/UniqueEntryList.java
@@ -98,6 +98,14 @@ public class UniqueEntryList<T extends Entry> implements Iterable<T> {
     }
 
     /**
+     * Updates the companyName of entries whose companyName matches {@code oldName} to be {@code newName}.
+     * Note: This function should only be called for Person and Event lists.
+     */
+    public void updateCompanyNames(String oldName, String newName) {
+        internalList.forEach(entry -> entry.updateCompanyName(oldName, newName));
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<T> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_EDITED;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -57,7 +58,7 @@ public class EditPersonCommandParserTest {
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", EditPersonCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", MESSAGE_NOT_EDITED);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -111,6 +111,9 @@ public class AddressBookTest {
         public ObservableList<Event> getEventList() {
             return events;
         }
+
+        @Override
+        public void updateCompanyNames(String oldName, String newName) { return; }
     }
 
 }


### PR DESCRIPTION
Fixes #54. #76 should be merged first before this one.

### Background

There is no `EditCompanyCommand`. Also, some of the code in the various edit command classes are unnecessarily duplicated. This PR adds an `EditCompanyCommand` and also takes out some of the duplicated code into `ParserUtil` or commons.core so that it can be reused.

Furthermore, to handle updating the `companyName` of Persons/Events which have the same `companyName` as the company that got updated, Entries now have a new function called `updateCompanyName()` which performs this updating. `AddressBook` and `UniqueEntryList` also have `updateCompanyNames()` functions to handle updating the company names of all the entries in the Persons/Events list. Although this means that Company now has a useless `updateCompanyName()` function it must override, this method allows for the updating of company names without breaking the abstraction barrier or having to refactor too much code.

### Let's

* add `EditCompanyCommand`
* move `MESSAGE_TO_EDIT` and `parseTags()` out of the edit command classes so that they can be reused
* update the `companyName` of Persons/Events which have the same `companyName` as the company that got updated
