### PR TITLE
Add ArchiveAll, DeleteAll, and UnarchiveAll Commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,3 +70,7 @@ shadowJar {
 }
 
 defaultTasks 'clean', 'test'
+
+run {
+    enableAssertions = true
+}

--- a/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class ArchiveAllCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
@@ -20,11 +20,11 @@ public class ArchiveAllCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Entry archivedEntry;
+        Entry archivedEntry = model.archiveEntry(0, true);
 
-        do {
-            archivedEntry = model.archiveEntry(1, true);
-        } while (archivedEntry != null);
+        for (int index = 1; archivedEntry != null; index++) {
+            archivedEntry = model.archiveEntry(index, true);
+        }
 
         // If the filteredList's predicate is UNARCHIVED_ONLY it will not update itself to remove the archived
         // entry, so we have to set it to a different predicate first.

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "All lists have been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAllCommand.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+public class DeleteAllCommand extends Command {
+    public static final String COMMAND_WORD = "delete_all";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes all entries in the displayed entry list.";
+
+    public static final String MESSAGE_DELETE_ALL_SUCCESS = "Deleted all entries.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        Entry deletedEntry;
+
+        do {
+            deletedEntry = model.deleteEntry(1);
+        } while (deletedEntry != null);
+
+        return new CommandResult(MESSAGE_DELETE_ALL_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || other instanceof DeleteCommand; // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAllCommand.java
@@ -17,11 +17,11 @@ public class DeleteAllCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        Entry deletedEntry;
+        Entry deletedEntry = model.deleteEntry(0);
 
-        do {
-            deletedEntry = model.deleteEntry(1);
-        } while (deletedEntry != null);
+        while (deletedEntry != null) {
+            deletedEntry = model.deleteEntry(0);
+        }
 
         return new CommandResult(MESSAGE_DELETE_ALL_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/FindCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCompanyCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEARCH_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -26,8 +28,8 @@ public class FindCompanyCommand extends Command {
             + "by name and tag.\n"
             + "Parameters: "
             + "[" + PREFIX_NAME + "NAME] "
-            + "[\" + PREFIX_SEARCH_TYPE + \"SEARCH_TYPE]"
-            + "[\" + PREFIX_TAG + \"TAG]...\n"
+            + "[" + PREFIX_SEARCH_TYPE + "SEARCH_TYPE]"
+            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "sgshop dbsss ";
 

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEARCH_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -29,8 +31,8 @@ public class FindPersonCommand extends Command {
             + "Parameters: "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_COMPANY + "COMPANY] "
-            + "[\" + PREFIX_SEARCH_TYPE + \"SEARCH_TYPE]"
-            + "[\" + PREFIX_TAG + \"TAG]...\n"
+            + "[" + PREFIX_SEARCH_TYPE + "SEARCH_TYPE]"
+            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "alice bob ";
 

--- a/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
@@ -2,41 +2,41 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL;
-import static seedu.address.model.Model.PREDICATE_SHOW_UNARCHIVED_ONLY;
+import static seedu.address.model.Model.PREDICATE_SHOW_ARCHIVED_ONLY;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
 
-public class ArchiveAllCommand extends Command {
-    public static final String COMMAND_WORD = "archive_all";
+public class UnarchiveAllCommand extends Command {
+    public static final String COMMAND_WORD = "unarchive_all";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Archives all entries in the displayed entry list.";
+            + ": Unarchives all entries in the displayed entry list.";
 
-    public static final String MESSAGE_ARCHIVE_ALL_SUCCESS = "Archived all entries";
+    public static final String MESSAGE_UNARCHIVE_ALL_SUCCESS = "Unarchived all entries.";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Entry archivedEntry;
+        Entry unarchivedEntry;
 
         do {
-            archivedEntry = model.archiveEntry(1, true);
-        } while (archivedEntry != null);
+            unarchivedEntry = model.archiveEntry(1, false);
+        } while (unarchivedEntry != null);
 
         // If the filteredList's predicate is UNARCHIVED_ONLY it will not update itself to remove the archived
         // entry, so we have to set it to a different predicate first.
         model.updateCurrentlyDisplayedList(PREDICATE_SHOW_ALL);
-        model.updateCurrentlyDisplayedList(PREDICATE_SHOW_UNARCHIVED_ONLY);
+        model.updateCurrentlyDisplayedList(PREDICATE_SHOW_ARCHIVED_ONLY);
 
-        return new CommandResult(MESSAGE_ARCHIVE_ALL_SUCCESS);
+        return new CommandResult(MESSAGE_UNARCHIVE_ALL_SUCCESS);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || other instanceof ArchiveCommand; // instanceof handles nulls
+                || other instanceof UnarchiveAllCommand; // instanceof handles nulls
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
@@ -20,11 +20,11 @@ public class UnarchiveAllCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Entry unarchivedEntry;
+        Entry unarchivedEntry = model.archiveEntry(0, false);
 
-        do {
-            unarchivedEntry = model.archiveEntry(1, false);
-        } while (unarchivedEntry != null);
+        for (int index = 1; unarchivedEntry != null; index++) {
+            unarchivedEntry = model.archiveEntry(index, false);
+        }
 
         // If the filteredList's predicate is UNARCHIVED_ONLY it will not update itself to remove the archived
         // entry, so we have to set it to a different predicate first.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.ListType;
 import seedu.address.logic.commands.AddCompanyCommand;
 import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.ArchiveAllCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -26,6 +27,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCompanyCommand;
 import seedu.address.logic.commands.ListEventCommand;
 import seedu.address.logic.commands.ListPersonCommand;
+import seedu.address.logic.commands.UnarchiveAllCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -104,8 +106,14 @@ public class AddressBookParser {
         case ArchiveCommand.COMMAND_WORD:
             return new ArchiveCommandParser().parse(arguments);
 
+        case ArchiveAllCommand.COMMAND_WORD:
+            return new ArchiveAllCommand();
+
         case UnarchiveCommand.COMMAND_WORD:
             return new UnarchiveCommandParser().parse(arguments);
+
+        case UnarchiveAllCommand.COMMAND_WORD:
+            return new UnarchiveAllCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteAllCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCompanyCommand;
 import seedu.address.logic.commands.EditEventCommand;
@@ -75,6 +76,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteAllCommand.COMMAND_WORD:
+            return new DeleteAllCommand();
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -288,7 +288,7 @@ public class ModelManager implements Model {
             Person personToArchive = filteredPersons.get(index);
             if (personToArchive.isArchived() == isArchived) {
                 String status = isArchived ? "Archived" : "not Archived";
-                throw new CommandException("This person is already " + status);
+                throw new CommandException(personToArchive.getName().toString() + " is already " + status);
             }
 
             addressBook.setArchivePerson(personToArchive, isArchived);
@@ -301,7 +301,7 @@ public class ModelManager implements Model {
             Company companyToArchive = filteredCompanies.get(index);
             if (companyToArchive.isArchived() == isArchived) {
                 String status = isArchived ? "Archived" : "not Archived";
-                throw new CommandException("This company is already " + status);
+                throw new CommandException(companyToArchive.getName().toString() + " is already " + status);
             }
 
             addressBook.setArchiveCompany(companyToArchive, isArchived);
@@ -314,7 +314,7 @@ public class ModelManager implements Model {
             Event eventToArchive = filteredEvents.get(index);
             if (eventToArchive.isArchived() == isArchived) {
                 String status = isArchived ? "Archived" : "not Archived";
-                throw new CommandException("This event is already " + status);
+                throw new CommandException(eventToArchive.getName().toString() + " is already " + status);
             }
 
             addressBook.setArchiveEvent(eventToArchive, isArchived);


### PR DESCRIPTION
Fixes #70 and fixes #71 

Previously, archiving, deleting, and unarchiving entries had to be done one at a time. Now you can archive/delete/unarchive all currently displayed entries in one go

### Let's

* add `ArchiveAll`, `DeleteAll`, and `UnarchiveAll` commands
* change the error message when archiving an already archived entry (or unarchiving an already unarchived entry) to show the entry's name
* fix some typos in the message usage of `FindCompanyCommand` and `FindPersonCommand`