### PR TITLE
Add cascading when deleting company

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -244,6 +244,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         events.updateCompanyNames(oldName, newName);
     }
 
+    /**
+     * Removes all entries whose companyName attribute has the same string as the given {@code companyName}.
+     * Note: Thie function should only be called for Person and Event lists.
+     */
+    public void removeMatchingCompanyName(String companyName) {
+        persons.removeMatchingCompanyName(companyName);
+        events.removeMatchingCompanyName(companyName);
+    }
+
     @Override
     public ObservableList<Event> getEventList() {
         return events.asUnmodifiableObservableList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -283,6 +283,7 @@ public class ModelManager implements Model {
 
             Company companyToDelete = filteredCompanies.get(index);
             deleteCompany(companyToDelete);
+            addressBook.removeMatchingCompanyName(companyToDelete.getName().toString());
             return companyToDelete;
         case EVENT:
             if (index >= filteredEvents.size()) {

--- a/src/main/java/seedu/address/model/entry/Company.java
+++ b/src/main/java/seedu/address/model/entry/Company.java
@@ -81,6 +81,9 @@ public class Company extends Entry {
         return;
     }
 
+    @Override
+    public boolean hasCompanyName(String testName) { return false; }
+
     /**
      * Returns true if both companies have the same identity and data fields.
      * This defines a stronger notion of equality between two companies.

--- a/src/main/java/seedu/address/model/entry/Email.java
+++ b/src/main/java/seedu/address/model/entry/Email.java
@@ -28,7 +28,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/main/java/seedu/address/model/entry/Entry.java
+++ b/src/main/java/seedu/address/model/entry/Entry.java
@@ -57,4 +57,10 @@ public abstract class Entry {
      * Note: This only applies for Person and Event. Company does not have any defined functionality for this.
      */
     public abstract void updateCompanyName(String oldName, String newName);
+
+    /**
+     * Returns true if the given companyName matches {@code testName}.
+     * Note: This only applies for Person and Event. Company does not have any defined functionality for this.
+     */
+    public abstract boolean hasCompanyName(String testName);
 }

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -79,7 +79,7 @@ public class Event extends Entry {
 
     @Override
     public void updateCompanyName(String oldName, String newName) {
-        if (oldName.equals(this.companyName.toString())) {
+        if (hasCompanyName(oldName)) {
             this.companyName = new Name(newName);
         }
     }

--- a/src/main/java/seedu/address/model/entry/Event.java
+++ b/src/main/java/seedu/address/model/entry/Event.java
@@ -84,6 +84,11 @@ public class Event extends Entry {
         }
     }
 
+    @Override
+    public boolean hasCompanyName(String testName) {
+        return testName.equals(companyName.toString());
+    }
+
     /**
      * Returns true if both events have the same identity and data fields.
      * This defines a stronger notion of equality between two events.

--- a/src/main/java/seedu/address/model/entry/Person.java
+++ b/src/main/java/seedu/address/model/entry/Person.java
@@ -68,7 +68,7 @@ public class Person extends Entry {
 
     @Override
     public void updateCompanyName(String oldName, String newName) {
-        if (oldName.equals(companyName.toString())) {
+        if (hasCompanyName(oldName)) {
             companyName = new Name(newName);
         }
     }

--- a/src/main/java/seedu/address/model/entry/Person.java
+++ b/src/main/java/seedu/address/model/entry/Person.java
@@ -68,9 +68,14 @@ public class Person extends Entry {
 
     @Override
     public void updateCompanyName(String oldName, String newName) {
-        if (oldName.equals(this.companyName.toString())) {
-            this.companyName = new Name(newName);
+        if (oldName.equals(companyName.toString())) {
+            companyName = new Name(newName);
         }
+    }
+
+    @Override
+    public boolean hasCompanyName(String testName) {
+        return testName.equals(companyName.toString());
     }
 
     /**

--- a/src/main/java/seedu/address/model/entry/UniqueEntryList.java
+++ b/src/main/java/seedu/address/model/entry/UniqueEntryList.java
@@ -140,6 +140,14 @@ public class UniqueEntryList<T extends Entry> implements Iterable<T> {
     }
 
     /**
+     * Removes all entries whose companyName attribute has the same string as the given {@code companyName}.
+     * Note: Thie function should only be called for Person and Event lists.
+     */
+    public void removeMatchingCompanyName(String companyName) {
+        internalList.removeIf(entry -> entry.hasCompanyName(companyName));
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<T> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -37,6 +37,7 @@ public class EmailTest {
 
         // invalid parts
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
+        assertFalse(Email.isValidEmail("peterjack@example")); // no pre-period domain name
         assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
         assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
         assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
@@ -59,9 +60,6 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part


### PR DESCRIPTION
Fixes #133 

### Background

Persons/events cannot exist without a company and must be tied to a specific company, so it makes sense that they should be edited/deleted when their company gets edited/deleted as well. This PR implements the deletion part of this cascading functionality.

It should be noted that this and cascading editing is implemented by adding two functions to the Entry class: `hasCompanyName()` and `updateCompanyName()`. These commands should only be called for Persons and Events; they have no functionality for Companies. Despite adding unnecessary functions to the Company class, this method for implementing it was chosen because it requires the least amount of changes to the existing framework. 

An alternative design solution would be to use the Observer pattern and then have a Company store all the Persons and Events with a matching companyName as observers. When the company has its name edited or when the company gets deleted, it can simply notify all its observers. However, this is tremendously difficult to implement as one would need to create Observer classes for the UniqueEntryList as well in order to do cascading deletion. There would also be some added complexity in following typing rules between the two kinds of Observer. Overall, the first design decision is much simpler and easier to implement.

### Let's

* implement cascading when deleting a company