### PR TITLE
Add tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -7,7 +7,7 @@ import seedu.address.commons.core.SearchTypeUtil.SearchType;
 import seedu.address.model.entry.Entry;
 
 public abstract class ListCommand extends Command {
-    private final SearchType searchType;
+    protected final SearchType searchType;
 
     public ListCommand(SearchType searchType) {
         this.searchType = searchType;

--- a/src/main/java/seedu/address/logic/commands/ListCompanyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCompanyCommand.java
@@ -32,4 +32,11 @@ public class ListCompanyCommand extends ListCommand {
         return new CommandResult(String.format(MESSAGE_SUCCESS, getSuccessMessage()),
                 false, false, false, true, false);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListCompanyCommand // instanceof handles nulls
+                && searchType.equals(((ListCompanyCommand) other).searchType)); // state check
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ListEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListEventCommand.java
@@ -35,4 +35,11 @@ public class ListEventCommand extends ListCommand {
         return new CommandResult(String.format(MESSAGE_SUCCESS, getSuccessMessage()),
                 false, false, false, false, true);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListEventCommand // instanceof handles nulls
+                && searchType.equals(((ListEventCommand) other).searchType)); // state check
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ListPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListPersonCommand.java
@@ -35,4 +35,11 @@ public class ListPersonCommand extends ListCommand {
         return new CommandResult(String.format(MESSAGE_SUCCESS, getSuccessMessage()),
                 false, false, true, false, false);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListPersonCommand // instanceof handles nulls
+                && searchType.equals(((ListPersonCommand) other).searchType)); // state check
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -18,7 +18,7 @@ public class UnarchiveCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_ARCHIVE_ENTRY_SUCCESS = "Unarchived Entry: %1$s\nListing all archived entries.";
+    public static final String MESSAGE_UNARCHIVE_ENTRY_SUCCESS = "Unarchived Entry: %1$s\nListing all archived entries.";
 
     private final Index targetIndex;
 
@@ -41,7 +41,7 @@ public class UnarchiveCommand extends Command {
         model.updateCurrentlyDisplayedList(PREDICATE_SHOW_ALL);
         model.updateCurrentlyDisplayedList(PREDICATE_SHOW_ARCHIVED_ONLY);
 
-        return new CommandResult(String.format(MESSAGE_ARCHIVE_ENTRY_SUCCESS, archivedEntry));
+        return new CommandResult(String.format(MESSAGE_UNARCHIVE_ENTRY_SUCCESS, archivedEntry));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -18,7 +18,8 @@ public class UnarchiveCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_UNARCHIVE_ENTRY_SUCCESS = "Unarchived Entry: %1$s\nListing all archived entries.";
+    public static final String MESSAGE_UNARCHIVE_ENTRY_SUCCESS = "Unarchived Entry: %1$s\n"
+            + "Listing all archived entries.";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -43,7 +43,7 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Name companyName = ParserUtil.parseCompanyName(argMultimap.getValue(PREFIX_COMPANY).get());
+        Name companyName = ParserUtil.parseName(argMultimap.getValue(PREFIX_COMPANY).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Time time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
         Location location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get());

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -38,7 +38,7 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Name companyName = ParserUtil.parseCompanyName(argMultimap.getValue(PREFIX_COMPANY).get());
+        Name companyName = ParserUtil.parseName(argMultimap.getValue(PREFIX_COMPANY).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEventCommandParser.java
@@ -45,7 +45,7 @@ public class EditEventCommandParser implements Parser<EditEventCommand> {
             editEventDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
-            editEventDescriptor.setCompanyName(ParserUtil.parseCompanyName(
+            editEventDescriptor.setCompanyName(ParserUtil.parseName(
                     argMultimap.getValue(PREFIX_COMPANY).get()));
         }
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditPersonCommandParser.java
@@ -43,7 +43,7 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_COMPANY).isPresent()) {
-            editPersonDescriptor.setCompanyName(ParserUtil.parseCompanyName(
+            editPersonDescriptor.setCompanyName(ParserUtil.parseName(
                     argMultimap.getValue(PREFIX_COMPANY).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindEventCommandParser.java
@@ -87,7 +87,7 @@ public class FindEventCommandParser implements Parser<FindEventCommand> {
         if (companyNamePresent) {
             List<String> dummy = Arrays.asList(argumentMultimap.getValue(PREFIX_COMPANY).get().split("\\s+"));
             for (String s : dummy) {
-                ParserUtil.parseCompanyName(s);
+                ParserUtil.parseName(s);
             }
         }
         if (startDatePresent) {

--- a/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
@@ -68,7 +68,7 @@ public class FindPersonCommandParser implements Parser<FindPersonCommand> {
         if (companyNamePresent) {
             List<String> dummy = Arrays.asList(argumentMultimap.getValue(PREFIX_COMPANY).get().split("\\s+"));
             for (String s : dummy) {
-                ParserUtil.parseCompanyName(s);
+                ParserUtil.parseName(s);
             }
         }
         if (tagPresent) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -146,22 +146,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String companyName} into an valid String.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given companyName is invalid.
-     */
-
-    public static Name parseCompanyName(String companyName) throws ParseException {
-        requireNonNull(companyName);
-        String trimmedCompanyName = companyName.replaceAll("\\s{2,}", " ").trim();
-        if (!Name.isValidName(trimmedCompanyName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
-        }
-        return new Name(trimmedCompanyName);
-    }
-
-    /**
      * Parses a {@code String date} into an {@code Date}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -190,7 +174,7 @@ public class ParserUtil {
         if (!Time.isValidTime(trimmedTime)) {
             throw new ParseException(Time.MESSAGE_CONSTRAINTS);
         }
-        return new Time(time);
+        return new Time(trimmedTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/entry/Location.java
+++ b/src/main/java/seedu/address/model/entry/Location.java
@@ -9,13 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Location {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "TODO CONSTRAINTS";
+    public static final String MESSAGE_CONSTRAINTS = "Location can take any values, and it should not be blank";
 
-    /*
-     * TODO VALIDATION REGEX
-     */
-    //public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String location;
 
@@ -32,11 +28,9 @@ public class Location {
 
     /**
      * Returns true if a given string is a valid location.
-     * TODO
      */
     public static boolean isValidLocation(String test) {
-        //return test.matches(VALIDATION_REGEX);
-        return true;
+        return test.matches(VALIDATION_REGEX);
     }
 
 

--- a/src/main/java/seedu/address/model/entry/Time.java
+++ b/src/main/java/seedu/address/model/entry/Time.java
@@ -24,7 +24,7 @@ public class Time {
     public Time(String time) {
         requireNonNull(time);
         checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
-        this.time = LocalTime.parse(time);;
+        this.time = LocalTime.parse(time);
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -72,5 +72,31 @@
     "tagged" : [ ],
     "isArchived": false
   } ],
-  "events": []
+  "events": [
+    {
+      "name" : "DBSSS Interview",
+      "company" : "DBSSS",
+      "date" : "2022-05-01",
+      "time" : "10:00",
+      "location" : "Zoom",
+      "tagged" : [ "Technical" ],
+      "isArchived" : false
+    }, {
+      "name" : "BB Interview",
+      "company" : "Big Bank",
+      "date" : "2022-06-05",
+      "time" : "12:30",
+      "location" : "16 Race Course Road",
+      "tagged" : [],
+      "isArchived" : false
+    }, {
+      "name" : "Online Assessment",
+      "company" : "Janice Street",
+      "date" : "2022-04-30",
+      "time" : "18:00",
+      "location" : "Hackerrank",
+      "tagged" : [ "Difficult" ],
+      "isArchived" : false
+    }
+  ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -49,6 +49,13 @@
     "email" : "anna@example.com",
     "tagged" : [ ],
     "isArchived": false
+  }, {
+    "name" : "Jane Lee",
+    "companyName": "Big Bank",
+    "phone" : "6444121",
+    "email" : "jane@example.com",
+    "tagged" : [ ],
+    "isArchived": true
   } ],
   "companies": [ {
     "name" : "DBSSS",

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.DBSSS;
+import static seedu.address.testutil.TypicalEntries.DBSSS;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
@@ -1,0 +1,119 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.entry.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code ArchiveCommand}.
+ */
+public class ArchiveCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void fixPersonsList() {
+        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredPersonList_success() throws CommandException {
+        Person personToArchive = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        ArchiveCommand archiveCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+
+        String expectedMessage = String.format(ArchiveCommand.MESSAGE_ARCHIVE_ENTRY_SUCCESS, personToArchive);
+
+        ModelManager expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        showUnarchivedPersons(expectedModel);
+        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), true);
+        expectedModel.showPersonList(Model.PREDICATE_SHOW_ALL);
+        showUnarchivedPersons(expectedModel);
+
+        assertCommandSuccess(archiveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
+
+        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredPersonList_success() throws CommandException {
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
+
+        Person personToArchive = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        ArchiveCommand archiveCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+
+        String expectedMessage = String.format(ArchiveCommand.MESSAGE_ARCHIVE_ENTRY_SUCCESS, personToArchive);
+
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        showUnarchivedPersons(expectedModel);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_ENTRY);
+        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), true);
+        showUnarchivedPersons(expectedModel);
+
+        assertCommandSuccess(archiveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredPersonList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
+
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
+
+        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ArchiveCommand archiveFirstCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+        ArchiveCommand archiveSecondCommand = new ArchiveCommand(INDEX_SECOND_ENTRY);
+
+        // same object -> returns true
+        assertTrue(archiveFirstCommand.equals(archiveFirstCommand));
+
+        // same values -> returns true
+        ArchiveCommand archiveFirstCommandCopy = new ArchiveCommand(INDEX_FIRST_ENTRY);
+        assertTrue(archiveFirstCommand.equals(archiveFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(archiveFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(archiveFirstCommand.equals(null));
+
+        // different index -> returns false
+        assertFalse(archiveFirstCommand.equals(archiveSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show all unarchived persons
+     */
+    private void showUnarchivedPersons(Model model) {
+        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -83,6 +83,7 @@ public class CommandTestUtil {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
+            expectedModel.equals(actualModel);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -13,10 +13,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.commons.core.ListType;
+import seedu.address.commons.core.SearchTypeUtil.SearchType;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.entry.Company;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 import seedu.address.model.entry.predicate.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -120,9 +124,72 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.showPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the company at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showCompanyAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredCompanyList().size());
+
+        Company company = model.getFilteredCompanyList().get(targetIndex.getZeroBased());
+        final String[] splitName = company.getName().fullName.split("\\s+");
+        model.showCompanyList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredCompanyList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the event at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showEventAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredEventList().size());
+
+        Event event = model.getFilteredEventList().get(targetIndex.getZeroBased());
+        final String[] splitName = event.getName().fullName.split("\\s+");
+        model.showEventList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredEventList().size());
+    }
+
+    public static CommandResult getExpectedListCommandResult(SearchType searchType, ListType listType) {
+        String searchTypeString = "";
+        String msgSuccess = "";
+
+        switch (searchType) {
+        case UNARCHIVED_ONLY:
+            searchTypeString = " unarchived";
+            break;
+        case ARCHIVED_ONLY:
+            searchTypeString = " archived";
+            break;
+        case ALL:
+            searchTypeString = "";
+            break;
+        default:
+            // should not reach here
+        }
+
+        switch (listType) {
+        case PERSON:
+            msgSuccess = ListPersonCommand.MESSAGE_SUCCESS;
+            break;
+        case COMPANY:
+            msgSuccess = ListCompanyCommand.MESSAGE_SUCCESS;
+            break;
+        case EVENT:
+            msgSuccess = ListEventCommand.MESSAGE_SUCCESS;
+            break;
+        default:
+            // should not reach here
+        }
+
+        return new CommandResult(String.format(msgSuccess, searchTypeString),
+                false, false, listType == ListType.PERSON, listType == ListType.COMPANY, listType == ListType.EVENT);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +35,8 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredPersonList_success() {
         showPerson(model);
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ENTRY);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ENTRY_SUCCESS, personToDelete);
 
@@ -58,10 +58,10 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexFilteredPersonList_success() {
         showPerson(model);
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ENTRY);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ENTRY_SUCCESS, personToDelete);
 
@@ -76,9 +76,9 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexFilteredPersonList_throwsCommandException() {
         showPerson(model);
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -89,14 +89,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_ENTRY);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_ENTRY);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_ENTRY);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -119,20 +119,6 @@ public class DeleteCommandTest {
     }
 
     private void showPerson(Model model) {
-        model.updateFilteredCompanyList(p -> false);
-        model.updateFilteredEventList(p -> false);
-        model.updateFilteredPersonList(p -> true);
-    }
-
-    private void showEvent(Model model) {
-        model.updateFilteredCompanyList(p -> false);
-        model.updateFilteredEventList(p -> true);
-        model.updateFilteredPersonList(p -> false);
-    }
-
-    private void showCompany(Model model) {
-        model.updateFilteredCompanyList(p -> true);
-        model.updateFilteredEventList(p -> false);
-        model.updateFilteredPersonList(p -> false);
+        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonCommandTest.java
@@ -10,9 +10,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ public class EditPersonCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_PERSON, descriptor);
+        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_ENTRY, descriptor);
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -80,8 +80,8 @@ public class EditPersonCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_ENTRY, new EditPersonDescriptor());
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -93,11 +93,11 @@ public class EditPersonCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_FIRST_ENTRY,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
@@ -111,20 +111,20 @@ public class EditPersonCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_SECOND_PERSON, descriptor);
+        EditPersonCommand editPersonCommand = new EditPersonCommand(INDEX_SECOND_ENTRY, descriptor);
 
         assertCommandFailure(editPersonCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
 
         // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_ENTRY.getZeroBased());
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_ENTRY,
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
@@ -145,8 +145,8 @@ public class EditPersonCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -158,11 +158,11 @@ public class EditPersonCommandTest {
 
     @Test
     public void equals() {
-        final EditPersonCommand standardCommand = new EditPersonCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditPersonCommand standardCommand = new EditPersonCommand(INDEX_FIRST_ENTRY, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditPersonCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditPersonCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST_ENTRY, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -175,10 +175,10 @@ public class EditPersonCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND_ENTRY, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST_ENTRY, DESC_BOB)));
     }
 
     private void showPerson(Model model) {

--- a/src/test/java/seedu/address/logic/commands/EditPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonCommandTest.java
@@ -52,6 +52,7 @@ public class EditPersonCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         showPerson(expectedModel);
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showPerson(expectedModel);
 
         assertCommandSuccess(editPersonCommand, model, expectedMessage, expectedModel);
     }
@@ -182,9 +183,7 @@ public class EditPersonCommandTest {
     }
 
     private void showPerson(Model model) {
-        model.updateFilteredCompanyList(p -> false);
-        model.updateFilteredEventList(p -> false);
-        model.updateFilteredPersonList(p -> true);
+        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/FindPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPersonCommandTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.CARL;
-import static seedu.address.testutil.TypicalPersons.ELLE;
-import static seedu.address.testutil.TypicalPersons.FIONA;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.CARL;
+import static seedu.address.testutil.TypicalEntries.ELLE;
+import static seedu.address.testutil.TypicalEntries.FIONA;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/seedu/address/logic/commands/ListCompanyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCompanyCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.getExpectedListCommandResult;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showCompanyAtIndex;
 import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
@@ -18,7 +18,7 @@ import seedu.address.model.UserPrefs;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListPersonCommand.
  */
-public class ListPersonCommandTest {
+public class ListCompanyCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -28,38 +28,38 @@ public class ListPersonCommandTest {
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        model.showCompanyList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        expectedModel.showCompanyList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.PERSON);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.COMPANY);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListCompanyCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsUnarchived() {
-        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
-        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.PERSON);
+        showCompanyAtIndex(model, INDEX_FIRST_ENTRY);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.COMPANY);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListCompanyCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsArchived() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.ARCHIVED_ONLY, ListType.PERSON);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.ARCHIVED_ONLY, ListType.COMPANY);
+        expectedModel.showCompanyList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.ARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListCompanyCommand(SearchType.ARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsAll() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.ALL, ListType.PERSON);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_ALL);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.ALL, ListType.COMPANY);
+        expectedModel.showCompanyList(Model.PREDICATE_SHOW_ALL);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.ALL), model, expectedCommandResult, expectedModel);
+                new ListCompanyCommand(SearchType.ALL), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListEventCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.getExpectedListCommandResult;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showEventAtIndex;
 import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
@@ -18,7 +18,7 @@ import seedu.address.model.UserPrefs;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListPersonCommand.
  */
-public class ListPersonCommandTest {
+public class ListEventCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -28,38 +28,38 @@ public class ListPersonCommandTest {
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        model.showEventList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        expectedModel.showEventList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.PERSON);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.EVENT);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListEventCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsUnarchived() {
-        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
-        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.PERSON);
+        showEventAtIndex(model, INDEX_FIRST_ENTRY);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.UNARCHIVED_ONLY, ListType.EVENT);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListEventCommand(SearchType.UNARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsArchived() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.ARCHIVED_ONLY, ListType.PERSON);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.ARCHIVED_ONLY, ListType.EVENT);
+        expectedModel.showEventList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.ARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
+                new ListEventCommand(SearchType.ARCHIVED_ONLY), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsAll() {
-        expectedCommandResult = getExpectedListCommandResult(SearchType.ALL, ListType.PERSON);
-        expectedModel.showPersonList(Model.PREDICATE_SHOW_ALL);
+        expectedCommandResult = getExpectedListCommandResult(SearchType.ALL, ListType.EVENT);
+        expectedModel.showEventList(Model.PREDICATE_SHOW_ALL);
         assertCommandSuccess(
-                new ListPersonCommand(SearchType.ALL), model, expectedCommandResult, expectedModel);
+                new ListEventCommand(SearchType.ALL), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UnarchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnarchiveCommandTest.java
@@ -22,40 +22,40 @@ import seedu.address.model.entry.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code ArchiveCommand}.
+ * {@code UnarchiveCommand}.
  */
-public class ArchiveCommandTest {
+public class UnarchiveCommandTest {
 
-    private Model model;
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @BeforeEach
     public void fixPersonsList() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        showArchivedPersons(model);
     }
 
     @Test
     public void execute_validIndexUnfilteredPersonList_success() throws CommandException {
         Person personToArchive = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
-        ArchiveCommand archiveCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(INDEX_FIRST_ENTRY);
 
-        String expectedMessage = String.format(ArchiveCommand.MESSAGE_ARCHIVE_ENTRY_SUCCESS, personToArchive);
+        String expectedMessage = String.format(UnarchiveCommand.MESSAGE_UNARCHIVE_ENTRY_SUCCESS, personToArchive);
 
         ModelManager expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        showUnarchivedPersons(expectedModel);
-        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), true);
+        showArchivedPersons(expectedModel);
+        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), false);
         expectedModel.showPersonList(Model.PREDICATE_SHOW_ALL);
-        showUnarchivedPersons(expectedModel);
+        showArchivedPersons(expectedModel);
 
-        assertCommandSuccess(archiveCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(unarchiveCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(outOfBoundIndex);
 
-        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+        assertCommandFailure(unarchiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
     }
 
     @Test
@@ -63,17 +63,17 @@ public class ArchiveCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_ENTRY);
 
         Person personToArchive = model.getFilteredPersonList().get(INDEX_FIRST_ENTRY.getZeroBased());
-        ArchiveCommand archiveCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(INDEX_FIRST_ENTRY);
 
-        String expectedMessage = String.format(ArchiveCommand.MESSAGE_ARCHIVE_ENTRY_SUCCESS, personToArchive);
+        String expectedMessage = String.format(UnarchiveCommand.MESSAGE_UNARCHIVE_ENTRY_SUCCESS, personToArchive);
 
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        showUnarchivedPersons(expectedModel);
+        showArchivedPersons(expectedModel);
         showPersonAtIndex(expectedModel, INDEX_FIRST_ENTRY);
-        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), true);
-        showUnarchivedPersons(expectedModel);
+        expectedModel.archiveEntry(INDEX_FIRST_ENTRY.getZeroBased(), false);
+        showArchivedPersons(expectedModel);
 
-        assertCommandSuccess(archiveCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(unarchiveCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -84,46 +84,47 @@ public class ArchiveCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        ArchiveCommand archiveCommand = new ArchiveCommand(outOfBoundIndex);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(outOfBoundIndex);
 
-        assertCommandFailure(archiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+        assertCommandFailure(unarchiveCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
     }
 
     @Test
-    public void execute_alreadyArchivedPerson_throwsCommandException() {
-        model.showPersonList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
-        Person archivedPerson = model.getFilteredPersonList().get(0);
-        ArchiveCommand archiveCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
+    public void execute_alreadyUnarchivedPerson_throwsCommandException() {
+        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+        Person unarchivedPerson = model.getFilteredPersonList().get(0);
+        UnarchiveCommand unarchiveCommand = new UnarchiveCommand(INDEX_FIRST_ENTRY);
 
-        assertCommandFailure(archiveCommand, model, archivedPerson.getName().toString() + " is already Archived");
+        assertCommandFailure(unarchiveCommand, model,
+                unarchivedPerson.getName().toString() + " is already not Archived");
     }
 
     @Test
     public void equals() {
-        ArchiveCommand archiveFirstCommand = new ArchiveCommand(INDEX_FIRST_ENTRY);
-        ArchiveCommand archiveSecondCommand = new ArchiveCommand(INDEX_SECOND_ENTRY);
+        UnarchiveCommand unarchiveFirstCommand = new UnarchiveCommand(INDEX_FIRST_ENTRY);
+        UnarchiveCommand unarchiveSecondCommand = new UnarchiveCommand(INDEX_SECOND_ENTRY);
 
         // same object -> returns true
-        assertTrue(archiveFirstCommand.equals(archiveFirstCommand));
+        assertTrue(unarchiveFirstCommand.equals(unarchiveFirstCommand));
 
         // same values -> returns true
-        ArchiveCommand archiveFirstCommandCopy = new ArchiveCommand(INDEX_FIRST_ENTRY);
-        assertTrue(archiveFirstCommand.equals(archiveFirstCommandCopy));
+        UnarchiveCommand archiveFirstCommandCopy = new UnarchiveCommand(INDEX_FIRST_ENTRY);
+        assertTrue(unarchiveFirstCommand.equals(archiveFirstCommandCopy));
 
         // different types -> returns false
-        assertFalse(archiveFirstCommand.equals(1));
+        assertFalse(unarchiveFirstCommand.equals(1));
 
         // null -> returns false
-        assertFalse(archiveFirstCommand.equals(null));
+        assertFalse(unarchiveFirstCommand.equals(null));
 
         // different index -> returns false
-        assertFalse(archiveFirstCommand.equals(archiveSecondCommand));
+        assertFalse(unarchiveFirstCommand.equals(unarchiveSecondCommand));
     }
 
     /**
      * Updates {@code model}'s filtered list to show all unarchived persons
      */
-    private void showUnarchivedPersons(Model model) {
-        model.showPersonList(Model.PREDICATE_SHOW_UNARCHIVED_ONLY);
+    private void showArchivedPersons(Model model) {
+        model.showPersonList(Model.PREDICATE_SHOW_ARCHIVED_ONLY);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
@@ -26,8 +26,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalEntries.AMY;
+import static seedu.address.testutil.TypicalEntries.BOB;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,8 +50,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_ENTRY), command);
     }
 
     @Test
@@ -59,8 +59,8 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
+                + INDEX_FIRST_ENTRY.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditPersonCommand(INDEX_FIRST_ENTRY, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArchiveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArchiveCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ArchiveCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the ArchiveCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the ArchiveCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class ArchiveCommandParserTest {
+
+    private ArchiveCommandParser parser = new ArchiveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new ArchiveCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ArchiveCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_ENTRY));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditPersonCommandParserTest.java
@@ -28,9 +28,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -107,7 +107,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND_ENTRY;
         String userInput = targetIndex.getOneBased() + COMPANY_DESC_AMY + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
@@ -121,7 +121,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
@@ -134,7 +134,7 @@ public class EditPersonCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD_ENTRY;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditPersonCommand expectedCommand = new EditPersonCommand(targetIndex, descriptor);
@@ -167,7 +167,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + COMPANY_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + COMPANY_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + COMPANY_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
@@ -183,7 +183,7 @@ public class EditPersonCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditPersonCommand expectedCommand = new EditPersonCommand(targetIndex, descriptor);
@@ -200,7 +200,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD_ENTRY;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEARCH_TYPE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.ListType;
+import seedu.address.commons.core.SearchTypeUtil.SearchType;
+import seedu.address.logic.commands.ListCompanyCommand;
+import seedu.address.logic.commands.ListEventCommand;
+import seedu.address.logic.commands.ListPersonCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the ListCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class ListCommandParserTest {
+    private static final String UNARCHIVED_INPUT = " " + PREFIX_SEARCH_TYPE + "unarchived";
+    private static final String ARCHIVED_INPUT = " " + PREFIX_SEARCH_TYPE + "archived";
+    private static final String ALL_INPUT = " " + PREFIX_SEARCH_TYPE + "all";
+
+    private final ListCommandParser listCompanyCommandParser = new ListCommandParser(ListType.COMPANY);
+    private final ListCommandParser listPersonCommandParser = new ListCommandParser(ListType.PERSON);
+    private final ListCommandParser listEventCommandParser = new ListCommandParser(ListType.EVENT);
+
+    @Test
+    public void parse_validArgs_returnsListCommand() {
+        assertParseSuccess(listCompanyCommandParser, UNARCHIVED_INPUT,
+                new ListCompanyCommand(SearchType.UNARCHIVED_ONLY));
+
+        assertParseSuccess(listCompanyCommandParser, ARCHIVED_INPUT,
+                new ListCompanyCommand(SearchType.ARCHIVED_ONLY));
+
+        assertParseSuccess(listCompanyCommandParser, ALL_INPUT,
+                new ListCompanyCommand(SearchType.ALL));
+
+        assertParseSuccess(listPersonCommandParser, UNARCHIVED_INPUT,
+                new ListPersonCommand(SearchType.UNARCHIVED_ONLY));
+
+        assertParseSuccess(listPersonCommandParser, ARCHIVED_INPUT,
+                new ListPersonCommand(SearchType.ARCHIVED_ONLY));
+
+        assertParseSuccess(listPersonCommandParser, ALL_INPUT,
+                new ListPersonCommand(SearchType.ALL));
+
+        assertParseSuccess(listEventCommandParser, UNARCHIVED_INPUT,
+                new ListEventCommand(SearchType.UNARCHIVED_ONLY));
+
+        assertParseSuccess(listEventCommandParser, ARCHIVED_INPUT,
+                new ListEventCommand(SearchType.ARCHIVED_ONLY));
+
+        assertParseSuccess(listEventCommandParser, ALL_INPUT,
+                new ListEventCommand(SearchType.ALL));
+    }
+
+    @Test
+    public void parse_invalidArgs_returnsListCommandUnarchived() {
+        assertParseSuccess(listCompanyCommandParser, "a", new ListCompanyCommand(SearchType.UNARCHIVED_ONLY));
+
+        assertParseSuccess(listPersonCommandParser, "a", new ListPersonCommand(SearchType.UNARCHIVED_ONLY));
+
+        assertParseSuccess(listEventCommandParser, "a", new ListEventCommand(SearchType.UNARCHIVED_ONLY));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -13,11 +13,16 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.OrderingUtil.Ordering;
+import seedu.address.commons.core.SearchTypeUtil.SearchType;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entry.Address;
+import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Email;
+import seedu.address.model.entry.Location;
 import seedu.address.model.entry.Name;
 import seedu.address.model.entry.Phone;
+import seedu.address.model.entry.Time;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -26,6 +31,12 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_DATE = "2022+04+19";
+    private static final String INVALID_TIME = "46:91";
+    private static final String INVALID_LOCATION = " ";
+    private static final String INVALID_SEARCH_TYPE = " not a search_type";
+    private static final String INVALID_ORDERING = "not an ordering";
+
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +44,11 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_DATE = "2021-05-08";
+    private static final String VALID_TIME = "16:22";
+    private static final String VALID_LOCATION = "Company Headquarters";
+    private static final String VALID_SEARCH_TYPE = "archived";
+    private static final String VALID_ORDERING = "descending";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +208,117 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseDate_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDate((String) null));
+    }
+
+    @Test
+    public void parseDate_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
+        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
+    }
+
+    @Test
+    public void parseTime_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTime((String) null));
+    }
+
+    @Test
+    public void parseTime_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTime(INVALID_TIME));
+    }
+
+    @Test
+    public void parseTime_validValueWithoutWhitespace_returnsTime() throws Exception {
+        Time expectedTime = new Time(VALID_TIME);
+        assertEquals(expectedTime, ParserUtil.parseTime(VALID_TIME));
+    }
+
+    @Test
+    public void parseTime_validValueWithWhitespace_returnsTrimmedTime() throws Exception {
+        String timeWithWhitespace = WHITESPACE + VALID_TIME + WHITESPACE;
+        Time expectedTime = new Time(VALID_TIME);
+        Time gottenTime = ParserUtil.parseTime(timeWithWhitespace);
+        assertEquals(expectedTime, ParserUtil.parseTime(timeWithWhitespace));
+    }
+
+    @Test
+    public void parseLocation_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseLocation((String) null));
+    }
+
+    @Test
+    public void parseLocation_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocation(INVALID_LOCATION));
+    }
+
+    @Test
+    public void parseLocation_validValueWithoutWhitespace_returnsLocation() throws Exception {
+        Location expectedLocation = new Location(VALID_LOCATION);
+        assertEquals(expectedLocation, ParserUtil.parseLocation(VALID_LOCATION));
+    }
+
+    @Test
+    public void parseLocation_validValueWithWhitespace_returnsTrimmedLocation() throws Exception {
+        String locationWithWhitespace = WHITESPACE + VALID_LOCATION + WHITESPACE;
+        Location expectedLocation = new Location(VALID_LOCATION);
+        assertEquals(expectedLocation, ParserUtil.parseLocation(locationWithWhitespace));
+    }
+
+    @Test
+    public void parseSearchType_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSearchType((String) null));
+    }
+
+    @Test
+    public void parseSearchType_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSearchType(INVALID_SEARCH_TYPE));
+    }
+
+    @Test
+    public void parseSearchType_validValueWithoutWhitespace_returnsSearchType() throws Exception {
+        assertEquals(SearchType.ARCHIVED_ONLY, ParserUtil.parseSearchType(VALID_SEARCH_TYPE));
+    }
+
+    @Test
+    public void parseSearchType_validValueWithWhitespace_returnsTrimmedSearchType() throws Exception {
+        String searchTypeWithWhitespace = WHITESPACE + VALID_SEARCH_TYPE + WHITESPACE;
+        assertEquals(SearchType.ARCHIVED_ONLY, ParserUtil.parseSearchType(searchTypeWithWhitespace));
+    }
+
+    @Test
+    public void parseOrdering_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseOrdering((String) null));
+    }
+
+    @Test
+    public void parseOrdering_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseOrdering(INVALID_ORDERING));
+    }
+
+    @Test
+    public void parseOrdering_validValueWithoutWhitespace_returnsOrdering() throws Exception {
+        assertEquals(Ordering.DESCENDING, ParserUtil.parseOrdering(VALID_ORDERING));
+    }
+
+    @Test
+    public void parseOrdering_validValueWithWhitespace_returnsTrimmedOrdering() throws Exception {
+        String orderingWithWhitespace = WHITESPACE + VALID_ORDERING + WHITESPACE;
+        assertEquals(Ordering.DESCENDING, ParserUtil.parseOrdering(orderingWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,10 +50,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_ENTRY, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_ENTRY, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnarchiveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnarchiveCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UnarchiveCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the UnarchiveCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the UnarchiveCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class UnarchiveCommandParserTest {
+
+    private UnarchiveCommandParser parser = new UnarchiveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new UnarchiveCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnarchiveCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/test/java/seedu/address/model/person/CompanyTest.java
+++ b/src/test/java/seedu/address/model/person/CompanyTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person;
+
+public class CompanyTest {
+}

--- a/src/test/java/seedu/address/model/person/DateTest.java
+++ b/src/test/java/seedu/address/model/person/DateTest.java
@@ -1,0 +1,63 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.entry.Date;
+
+public class DateTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Date(null));
+    }
+
+    @Test
+    public void constructor_invalidDate_throwsIllegalArgumentException() {
+        String invalidDate = "";
+        assertThrows(IllegalArgumentException.class, () -> new Date(invalidDate));
+    }
+
+    @Test
+    public void isValidDate() {
+        // null
+        assertThrows(NullPointerException.class, () -> Date.isValidDate(null));
+
+        // blank time
+        assertFalse(Date.isValidDate(""));
+        assertFalse(Date.isValidDate(" "));
+
+        // invalid time formats
+        assertFalse(Date.isValidDate("Abba"));
+        assertFalse(Date.isValidDate("1234"));
+        assertFalse(Date.isValidDate("FAAFLJAJL14@$$?LK}!%%K!"));
+        assertFalse(Date.isValidDate("Dec. 04, 2021")); // MMM. YY, DDDD
+        assertFalse(Date.isValidDate("04-20-2021")); // MM-DD-YYYY
+        assertFalse(Date.isValidDate("18-01-2019")); // DD-MM-YYYY
+        assertFalse(Date.isValidDate("11-06")); // year part missing
+        assertFalse(Date.isValidDate("2019-03")); // month/day part missing
+        assertFalse(Date.isValidDate("2021-08-1")); // day only 1 character long
+        assertFalse(Date.isValidDate("2021-5-19")); // month only 1 character long
+        assertFalse(Date.isValidDate("999-06-14")); // year only 3 characters long
+
+        // invalid dates
+        assertFalse(Date.isValidDate("2019-13-01")); // month too high
+        assertFalse(Date.isValidDate("2020-00-12")); // month too low
+        assertFalse(Date.isValidDate("2021-01-32")); // day too high
+        assertFalse(Date.isValidDate("2021-02-30")); // day too high
+        assertFalse(Date.isValidDate("2021-04-31")); // day too high
+        assertFalse(Date.isValidDate("2017-06-00")); // day too low
+
+        // valid times
+        assertTrue(Date.isValidDate("2022-12-20")); // highest possible month value
+        assertTrue(Date.isValidDate("2022-01-08")); // lowest possible month value
+        assertTrue(Date.isValidDate("2020-05-31")); // highest possible day value
+        assertTrue(Date.isValidDate("2018-09-30")); // highest possible day value
+        assertTrue(Date.isValidDate("2021-02-28")); // highest possible day value
+        assertTrue(Date.isValidDate("2020-02-29")); // highest possible day value
+        assertTrue(Date.isValidDate("2019-07-01")); // lowest possible day value
+        assertTrue(Date.isValidDate("2015-10-17")); // average year/month/day value
+    }
+}

--- a/src/test/java/seedu/address/model/person/LocationTest.java
+++ b/src/test/java/seedu/address/model/person/LocationTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person;
+
+public class LocationTest {
+}

--- a/src/test/java/seedu/address/model/person/LocationTest.java
+++ b/src/test/java/seedu/address/model/person/LocationTest.java
@@ -1,4 +1,37 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.entry.Location;
+
 public class LocationTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Location(null));
+    }
+
+    @Test
+    public void constructor_invalidLocation_throwsIllegalArgumentException() {
+        String invalidLocation = "";
+        assertThrows(IllegalArgumentException.class, () -> new Location(invalidLocation));
+    }
+
+    @Test
+    public void isValidLocation() {
+        // null location
+        assertThrows(NullPointerException.class, () -> Location.isValidLocation(null));
+
+        // invalid locations
+        assertFalse(Location.isValidLocation(""));
+        assertFalse(Location.isValidLocation(" "));
+
+        // valid locations
+        assertTrue(Location.isValidLocation("Company Headquarters at 129 St."));
+        assertTrue(Location.isValidLocation(">")); // one character
+        assertTrue(Location.isValidLocation("Down the Road; Across the Street; To the Left; Behind the Lamppost"));
+    }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -8,8 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.BOB;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/person/TimeTest.java
+++ b/src/test/java/seedu/address/model/person/TimeTest.java
@@ -1,0 +1,57 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.entry.Time;
+
+public class TimeTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Time(null));
+    }
+
+    @Test
+    public void constructor_invalidTime_throwsIllegalArgumentException() {
+        String invalidTime = "";
+        assertThrows(IllegalArgumentException.class, () -> new Time(invalidTime));
+    }
+
+    @Test
+    public void isValidTime() {
+        // null
+        assertThrows(NullPointerException.class, () -> Time.isValidTime(null));
+
+        // blank time
+        assertFalse(Time.isValidTime(""));
+        assertFalse(Time.isValidTime(" "));
+
+        // invalid time formats
+        assertFalse(Time.isValidTime("Abba"));
+        assertFalse(Time.isValidTime("1234"));
+        assertFalse(Time.isValidTime("FAAFLJAJL14@$$?LK}!%%K!"));
+        assertFalse(Time.isValidTime("FF:AA")); // letters instead of numbers
+        assertFalse(Time.isValidTime("@@:LL")); // symbols instead of numbers
+        assertFalse(Time.isValidTime("1:23")); // hour part only 1 character long
+        assertFalse(Time.isValidTime("12:1")); // minute part only 1 character long
+        assertFalse(Time.isValidTime("400:34")); // hour part only 3 characters long
+        assertFalse(Time.isValidTime("2:415")); // minute part only 3 characters long
+
+        // invalid times
+        assertFalse(Time.isValidTime("24:00")); // hour too high
+        assertFalse(Time.isValidTime("13:60")); // minute too high
+        assertFalse(Time.isValidTime("08:75")); // minute too high
+        assertFalse(Time.isValidTime("41:29")); // hour too high
+
+        // valid times
+        assertTrue(Time.isValidTime("08:59")); // highest possible minute value
+        assertTrue(Time.isValidTime("16:00")); // lowest possible minute value
+        assertTrue(Time.isValidTime("23:36")); // highest possible hour value
+        assertTrue(Time.isValidTime("00:14")); // lowest possible hour value
+        assertTrue(Time.isValidTime("13:29")); // average time value
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.BOB;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalEntries.BENSON;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -3,10 +3,10 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.HOON;
-import static seedu.address.testutil.TypicalPersons.IDA;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.HOON;
+import static seedu.address.testutil.TypicalEntries.IDA;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.TypicalPersons;
+import seedu.address.testutil.TypicalEntries;
 
 public class JsonSerializableAddressBookTest {
 
@@ -25,7 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        AddressBook typicalPersonsAddressBook = TypicalEntries.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import java.nio.file.Path;
 

--- a/src/test/java/seedu/address/testutil/EventBuilder.java
+++ b/src/test/java/seedu/address/testutil/EventBuilder.java
@@ -1,0 +1,108 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.entry.Date;
+import seedu.address.model.entry.Event;
+import seedu.address.model.entry.Location;
+import seedu.address.model.entry.Name;
+import seedu.address.model.entry.Time;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Event objects.
+ */
+public class EventBuilder {
+
+    public static final String DEFAULT_NAME = "DBSSS Interview";
+    public static final String DEFAULT_COMPANY = "DBSSS";
+    public static final String DEFAULT_DATE = "2022-05-01";
+    public static final String DEFAULT_TIME = "10:00";
+    public static final String DEFAULT_LOCATION = "Zoom";
+
+    private Name name;
+    private Name companyName;
+    private Date date;
+    private Time time;
+    private Location location;
+    private Set<Tag> tags;
+
+    /**
+     * Creates a {@code EventBuilder} with the default details.
+     */
+    public EventBuilder() {
+        name = new Name(DEFAULT_NAME);
+        companyName = new Name(DEFAULT_COMPANY);
+        date = new Date(DEFAULT_DATE);
+        time = new Time(DEFAULT_TIME);
+        location = new Location(DEFAULT_LOCATION);
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes the EventBuilder with the data of {@code eventToCopy}.
+     */
+    public EventBuilder(Event eventToCopy) {
+        name = eventToCopy.getName();
+        companyName = eventToCopy.getCompanyName();
+        date = eventToCopy.getDate();
+        time = eventToCopy.getTime();
+        location = eventToCopy.getLocation();
+        tags = new HashSet<>(eventToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Event} that we are building.
+     */
+    public EventBuilder withName(String name) {
+        this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Event} that we are building.
+     */
+    public EventBuilder withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Sets the {@code companyName} of the {@code Event} that we are building.
+     */
+    public EventBuilder withCompanyName(String companyName) {
+        this.companyName = new Name(companyName);
+        return this;
+    }
+
+    /**
+     * Sets the {@code date} of the {@code Event} that we are building.
+     */
+    public EventBuilder withDate(String date) {
+        this.date = new Date(date);
+        return this;
+    }
+
+    /**
+     * Sets the {@code time} of the {@code Event} that we are building.
+     */
+    public EventBuilder withTime(String time) {
+        this.time = new Time(time);
+        return this;
+    }
+
+    /**
+     * Sets the {@code location} of the {@code Event} that we are building.
+     */
+    public EventBuilder withLocation(String location) {
+        this.location = new Location(location);
+        return this;
+    }
+
+    public Event build() {
+        return new Event(name, companyName, date, time, location, tags);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -19,12 +19,14 @@ public class PersonBuilder {
     public static final String DEFAULT_COMPANY = "DBSSS";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final boolean DEFAULT_ARCHIVED = false;
 
     private Name name;
     private Name companyName;
     private Phone phone;
     private Email email;
     private Set<Tag> tags;
+    private boolean isArchived;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -35,6 +37,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         tags = new HashSet<>();
+        isArchived = DEFAULT_ARCHIVED;
     }
 
     /**
@@ -46,6 +49,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         tags = new HashSet<>(personToCopy.getTags());
+        isArchived = personToCopy.isArchived();
     }
 
     /**
@@ -88,8 +92,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code isArchived} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withArchived(boolean isArchived) {
+        this.isArchived = isArchived;
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, companyName, phone, email, tags);
+        return new Person(name, companyName, phone, email, tags, isArchived);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -17,12 +17,13 @@ import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.entry.Company;
+import seedu.address.model.entry.Event;
 import seedu.address.model.entry.Person;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
  */
-public class TypicalPersons {
+public class TypicalEntries {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline").withCompanyName("DBSSS")
             .withEmail("alice@example.com").withPhone("94351253").withTags("friends").build();
@@ -46,6 +47,14 @@ public class TypicalPersons {
     public static final Company JANICE_STREET = new CompanyBuilder().withName("Janice Street").withPhone("89245223")
             .withEmail("janicestreet@example.com").withAddress("21 Marina Bay Sands").build();
 
+    public static final Event INTERVIEW_A = new EventBuilder().withName("DBSSS Interview").withCompanyName("DBSSS")
+            .withDate("2022-05-01").withTime("10:00").withLocation("Zoom").withTags("Technical").build();
+    public static final Event INTERVIEW_B = new EventBuilder().withName("BB Interview").withCompanyName("Big Bank")
+            .withDate("2022-06-05").withTime("12:30").withLocation("16 Race Course Road").build();
+    public static final Event ONLINE_ASSESSMENT = new EventBuilder().withName("Online Assessment")
+            .withCompanyName("Janice Street").withDate("2022-04-30").withTime("18:00").withLocation("Hackerrank")
+            .withTags("Difficult").build();
+
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withCompanyName("Janice Street")
             .withPhone("8482424").withEmail("stefan@example.com").build();
@@ -61,7 +70,7 @@ public class TypicalPersons {
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
-    private TypicalPersons() {} // prevents instantiation
+    private TypicalEntries() {} // prevents instantiation
 
     /**
      * Returns an {@code AddressBook} with all the typical persons.
@@ -74,11 +83,18 @@ public class TypicalPersons {
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);
         }
+        for (Event event : getTypicalEvents()) {
+            ab.addEvent(event);
+        }
         return ab;
     }
 
     public static List<Company> getTypicalCompanies() {
         return new ArrayList<>(Arrays.asList(DBSSS, BIG_BANK, JANICE_STREET));
+    }
+
+    public static List<Event> getTypicalEvents() {
+        return new ArrayList<>(Arrays.asList(INTERVIEW_A, INTERVIEW_B, ONLINE_ASSESSMENT));
     }
 
     public static List<Person> getTypicalPersons() {

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -39,6 +39,8 @@ public class TypicalEntries {
             .withPhone("9482427").withEmail("lydia@example.com").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withCompanyName("Big Bank")
             .withPhone("9482442").withEmail("anna@example.com").build();
+    public static final Person JANE = new PersonBuilder().withName("Jane Lee").withCompanyName("Big Bank")
+            .withPhone("6444121").withEmail("jane@example.com").withArchived(true).build();
 
     public static final Company DBSSS = new CompanyBuilder().withName("DBSSS").withPhone("91123671")
             .withEmail("dbsss@example.com").withAddress("14 Jurong Street").build();
@@ -73,18 +75,20 @@ public class TypicalEntries {
     private TypicalEntries() {} // prevents instantiation
 
     /**
-     * Returns an {@code AddressBook} with all the typical persons.
+     * Returns an {@code AddressBook} with all the typical entries.
+     * A copy of each of the static entries above is made so that different calls
+     * to this method will not be referring to the same entry objects.
      */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         for (Company company : getTypicalCompanies()) {
-            ab.addCompany(company);
+            ab.addCompany(new CompanyBuilder(company).build());
         }
         for (Person person : getTypicalPersons()) {
-            ab.addPerson(person);
+            ab.addPerson(new PersonBuilder(person).build());
         }
         for (Event event : getTypicalEvents()) {
-            ab.addEvent(event);
+            ab.addEvent(new EventBuilder(event).build());
         }
         return ab;
     }
@@ -98,6 +102,6 @@ public class TypicalEntries {
     }
 
     public static List<Person> getTypicalPersons() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE, JANE));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_ENTRY = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_ENTRY = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_ENTRY = Index.fromOneBased(3);
 }


### PR DESCRIPTION
### Tests added
* 3 list commands and ListCommandParser
* Date
* Location
* Time
* ArchiveCommand and its parser
* UnarchiveCommand and its parser

### Test Util Changes
* Refactor TypicalPersons --> TypicalEntries 
* Update TypicalEntries with 1 archived Person entry as well as with Event entries
* Update typicalPersonsAddressBook accordingly
* Update all instances of showPerson in the command tests to be `model.showPersonList(PREDICATE_SHOW_UNARCHIVED_ONLY);`

### Other changes
* Remove unnecessary semicolon in `Time`
* Remove `parseCompanyName()` in `ParserUtil` (all instances of this are changed to `parseName()`)
* Fix bug with trimmed Time string in `ParserUtil`
* Add validation regex for `Location`
* Add `equals()` function for the 3 list commands
* Change `MESSAGE_ARCHIVE_ENTRY_SUCCESS` in `UnarchiveCommand` to `MESSAGE_ARCHIVE_ENTRY_SUCCESS`