### PR TITLE
Fix user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -13,15 +13,15 @@ The purpose of this User Guide is to assist you in learning and using InternBudd
 --------------------------------------------------------------------------------------------------------------------
 
 ## Quick start
-If you feel InternBuddy is the solution to your problem and you're interested in using it, try it out now! If this is your first time using InternBuddy, you can get started right away by following the steps below.
+If you're interested in using InternBuddy but don't know where to begin, this section will give you a step-by-step walkthrough to get you started!
 1. Ensure you have Java `11` or above installed in your Computer.
    * If you don't have it installed, you can follow [Oracle's JDK installation guide](https://docs.oracle.com/en/java/javase/11/install/installation-guide.pdf)
    for your operating system.
-   * Please make sure that you select Java `11` as your default Java version.
+   * Also ensure that you have selecte Java `11` as your default Java version.
    * If you are not sure which version of Java that you currently have, you can follow [Java Manual](https://www.java.com/en/download/help/version_manual.html)
    to check.
 
-2. Download the latest `InternBuddy.jar` from [here](https://github.com/AY2122S2-CS2103T-W14-3/tp/releases/download/v1.3.1/internbuddy.jar).
+2. Download the latest `InternBuddy.jar` from [here](https://github.com/AY2122S2-CS2103T-W14-3/tp/releases/download/v1.4/internbuddy.jar).
 
 3. Copy the file to the folder you want to use as the _home folder_ for InternBuddy.
 
@@ -35,32 +35,40 @@ If you feel InternBuddy is the solution to your problem and you're interested in
 
    * **`addc`**`n/DeeBee p/98765432 e/dbs@example.com a/14 Jurong Street #01-01` : Adds a company named `DeeBee` to the list of companies.
 
-   * **`delete`**`3` : Deletes the 3rd contact shown in the current list.
+   * **`delete`**`3` : Deletes the 3rd contact shown in the currently displayed list.
 
-   * **`clear`** : Deletes all entries.
+   * **`delete_all`** : Deletes all entries in the currently displayed list.
 
    * **`exit`** : Exits the app.
 
 6. If this is your first time reading our user guide, you can refer to our [Guide Walkthrough](#guide-walkthrough) section to learn how to navigate the guide, and eventually the app.
 
-----
-## Guide Walkthrough
-If you're new, welcome to **InternBuddy**! We're trying to make this guide as easy to read as possible. We hope this section will help you read the guide and get started with InternBuddy.
+--------------------------------------------------------------------------------------------------------------------
+## Overview of Internbuddy
 
-### Overview of InternBuddy
-InternBuddy is designed specifically for students who are searching for internships. With InternBuddy, there is no need for you to juggle between multiple apps just to manage your multiple internship applications. With efficiency as its focus, InternBuddy values your **Time** and **Experience**. Let InterBuddy help you to manage your application details so you can focus acing your assessments and interviews!
+InternBuddy is designed specifically for students who are searching for internships. With InternBuddy, there is no need
+for you to juggle between multiple apps just to manage your multiple internship applications. This app values your
+**Time** and **Experience** by placing efficiency as one of its core principles. Let InternBuddy help you manage your 
+internship application details so you can focus on acing your assessments and interviews!
+
+This section will go into detail as to how the app works.
+
 ### Structure of InternBuddy
-With internships and job seeking as our main focus, we are going over 3 main entries of InternBuddy:
-- **Company**: A company will represent a  company that you are applying for, or will be applying for.
-- **Person**: A person will represent a contact person. In can be used for general purpose of storing a contact person with a company related to it. The contact person may have a specific role such as the HR of a company.
-- **Event**: An event will represent an event of a company. An event can be an online assessment, an interview, a job fair, etc.
 
-And with that, InternBuddy stores 3 lists for 3 different types of entries:
-- **[Companies](#company-list)**
-- **[Persons](#person-list)**
-- **[Events](#event-list)**
+Because internships and job seeking is InternBuddy's main focus, the app supports 3 kinds of entries:
+- **Company**: Represents a company that you are applying for, or will be applying for.
+- **Person**: Represents a contact person of a company. The contact person may have a specific role such as being an HR recruiter.
+- **Event**: Represents an event of a company. An event can be an online assessment, an interview, a job fair, etc.
 
-The app will only display one of these lists at any time, as shown in the screenshot below. Each of these 3 different types have different attributes attached to them. Let's dive in to understand what each type can store.
+With that, InternBuddy stores 3 entry lists, one for each entry type:
+- **[Company List](#company-list)**
+- **[Person List](#person-list)**
+- **[Event List](#event-list)**
+
+The app will only display one of these lists at any time, as shown in the screenshots of each of these lists.
+
+Each of these 3 entry types have different attributes attached to them. Let's dive in to understand what attributes each
+entry type can store.
 
 #### Company List
 ![Company List](images/UserGuide/Ui-2.png)
@@ -126,7 +134,10 @@ Since **InternBuddy** is designed to be used via a Command Line Interface (CLI),
   - [`findp`](#locating-people-by-name-findp): Finds a person.
   - [`finde`](#locating-events-finde): Finds an event. 
 
-There are other commands such as [`help`](#viewing-help--help), [`clear`](#clearing-all-entries--clear), and [`exit`](#exiting-the-program--exit). You can try clicking on the commands above to see how to use them in further details. However, we would suggest you to read the [User Guide Icons](#user-guide-icons) and [Command Formats](#command-formats) section first to have a smoother experience reading our [Features](#features) section :smile:.
+There are other commands such as [`help`](#viewing-help--help), [`clear`](#clearing-all-entries--clear), and [`exit`](#exiting-the-program--exit).
+You can try clicking on the commands above to see how to use them in further details. However, we would suggest you to
+read the [User Guide Icons](#icons) and [Command Formats](#command-formats) section first to have a smoother
+experience reading our [Features](#features) section :smile:.
 
 #### Dialog Box
 For those of you not familiar with what a dialog box is, a dialog box is a box that shows when you execute a command. It is a box that contains a message. The message is basically a feedback from InternBuddy to you. InternBuddy will show you a dialog box when you execute a command.
@@ -139,12 +150,18 @@ Otherwise, if the command is **valid**, a **success message** will be shown and 
 
 ![successful command](images/SuccessfulCommandExample.png)
 
-### User Guide Icons
+--------------------------------------------------------------------------------------------------------------------
+## Features Walkthrough
+This section will help you navigate and understand the [Features](#features) section of the guide.
+This way, you can easily use it to answer any question you have regarding the app's features.
 
-| Icon               | Meaning                                                       |
-|--------------------|---------------------------------------------------------------|
-|:information_source:| This icon indicates important information to be taken note of |
-|:bulb:               | This icon indicates useful tips for the users                |
+### Icons
+
+| Icon                 | Meaning                                                                                           |
+|----------------------|---------------------------------------------------------------------------------------------------|
+| :information_source: | This icon indicates important information to be taken note of                                     |
+| :bulb:               | This icon indicates useful tips for the users                                                     |
+| :exclamation:        | This icon indicates caution for an action the user can take that can have dangerous consequences. |
 
 ### Command Formats
 With a simple command standards, we tried to make the commands as intuitive as possible. To make sure that you can read the commands without any confusion, here are the formats we use in the guide.
@@ -223,7 +240,7 @@ Format:
 addp n/NAME c/COMPANY_NAME p/PHONE_NUMBER e/EMAIL [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-info">:information_source: **Note:**
 `COMPANY_NAME` must match the name of an existing Company in the Company list.
 </div>
 
@@ -240,7 +257,7 @@ Format:
 adde n/NAME c/COMPANY_NAME d/DATE ti/TIME l/LOCATION [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 `DATE` must be in the format:
 * YYYY-MM-DD
 * "today" (which will get the `DATE` for today)
@@ -253,7 +270,7 @@ E.g. 2022-10-20 and 13:30, or "today 10" and 12:45.
 the keyword "today" for DATE is case-insensitive.
 </div>
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 `COMPANY_NAME` must match the name of an existing Company in the Company list.
 </div>
 
@@ -326,7 +343,7 @@ Format:
 editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…
 ```
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 If the name of the Company is edited, all Events and Persons referring to the Company will also
 update the company name they have stored.
 </div>
@@ -348,7 +365,7 @@ Format:
 editp INDEX [n/NAME] [c/COMPANY_NAME] [p/PHONE] [e/EMAIL] [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 `COMPANY_NAME` must match the name of an existing Company in the Company list.
 </div>
 
@@ -365,12 +382,12 @@ Format:
 edite INDEX [n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…
 ```
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 `DATE` must be in the format YYYY-MM-DD, while `TIME` must be in the format HH:MM.
 E.g. 2022-10-20 and 13:30.
 </div>
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 `COMPANY_NAME` must match the name of an existing Company in the Company list.
 </div>
 
@@ -425,7 +442,7 @@ Examples:
 
 Finds events with given details of the event by name, company, start date, end date, time, location and tag
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 START DATE and END DATE will find events from the START DATE to the END DATE **inclusively**.
 </div>
 
@@ -502,7 +519,7 @@ archive INDEX
 Examples:
 * `archive 1` hides the 1st entry from the list of entries.
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 display all unarchived entries first to get the INDEX of the entry you want to archive.
 </div>
 
@@ -525,7 +542,7 @@ unarchive INDEX
 Examples:
 * `unarchive 1` shows the 1st entry in the list of entries.
 
-<div markdown="span" class="alert alert-warning">:grey_exclamation: **Note:**
+<div markdown="span" class="alert alert-primary">:information_source: **Note:**
 display all archived entries first to get the INDEX of the entry you want to unarchive.
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -44,9 +44,9 @@ If you're interested in using InternBuddy but don't know where to begin, this se
 6. If this is your first time reading our user guide, you can refer to our [Guide Walkthrough](#guide-walkthrough) section to learn how to navigate the guide, and eventually the app.
 
 --------------------------------------------------------------------------------------------------------------------
-## Overview of Internbuddy
+## Overview of InternBuddy
 
-InternBuddy is designed specifically for students who are searching for internships. With InternBuddy, there is no need
+InternBuddy is specially designed for students who are searching for internships. With InternBuddy, there is no need
 for you to juggle between multiple apps just to manage your multiple internship applications. This app values your
 **Time** and **Experience** by placing efficiency as one of its core principles. Let InternBuddy help you manage your 
 internship application details so you can focus on acing your assessments and interviews!
@@ -65,7 +65,8 @@ With that, InternBuddy stores 3 entry lists, one for each entry type:
 - **[Person List](#person-list)**
 - **[Event List](#event-list)**
 
-The app will only display one of these lists at any time, as shown in the screenshots of each of these lists.
+The app will only display one of these lists at any time, as shown in the screenshots of each of these lists. Lists cannot
+have duplicate entries; the criteria for what counts as a duplicate entry will be listed in the sections below.
 
 Each of these 3 entry types have different attributes attached to them. Let's dive in to understand what attributes each
 entry type can store.
@@ -80,6 +81,8 @@ A **Company** entry has:
 * A *real-life address*
 * Zero or more *tags* associated with them
 
+Two Company entries are considered duplicates of each other if they have the same name.
+
 #### Person List
 ![Person List](images/UserGuide/Ui-3.png)
 
@@ -89,6 +92,8 @@ A **Person** entry has:
 * An *email address*
 * A *phone number*
 * Zero or more *tags* associated with them
+
+Two Person entries are considered duplicates of each other if they have the same name.
 
 #### Event List
 ![Event List](images/UserGuide/Ui-4.png)
@@ -100,6 +105,8 @@ Finally, an **Event** entry has:
 * A *time*
 * A *location*
 * Zero or more *tags* associated with them
+
+Two Event entries are considered duplicates of each other if they have the same name, date, time, and company name.
 
 ### Interacting with the app
 Since **InternBuddy** is designed to be used via a Command Line Interface (CLI), you will be interacting with the app mostly through typing the commands. To interact with this app, you **type commands into the command box** and **hit the Enter key** when you are done.<br/>
@@ -136,7 +143,7 @@ Since **InternBuddy** is designed to be used via a Command Line Interface (CLI),
 
 There are other commands such as [`help`](#viewing-help--help), [`clear`](#clearing-all-entries--clear), and [`exit`](#exiting-the-program--exit).
 You can try clicking on the commands above to see how to use them in further details. However, we would suggest you to
-read the [User Guide Icons](#icons) and [Command Formats](#command-formats) section first to have a smoother
+read the [Features Guide](#features-guide) section first to have a smoother
 experience reading our [Features](#features) section :smile:.
 
 #### Dialog Box
@@ -149,6 +156,11 @@ If the command you tried to execute is **invalid** for whatever reason, an **err
 Otherwise, if the command is **valid**, a **success message** will be shown and the command will be executed. The command box will also be cleared.
 
 ![successful command](images/SuccessfulCommandExample.png)
+
+#### Archive
+InternBuddy supports archiving entries. When an entry is archived, it will be "hidden" from the entry list unless the user
+specifically chooses to display them. However, the entry can be unarchived when needed, and it will still technically
+exist in the entry list. For example, an Event or Person can still store the company name of an archived Company.
 
 --------------------------------------------------------------------------------------------------------------------
 ## Features Guide
@@ -214,7 +226,7 @@ An empty input or an input consisting only of spaces is invalid for every parame
   * If no `o/` parameter is given, InternBuddy will default to `ascending`.
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-The keyword "today" for `DATE`, `START_DATE`, and `END_DATE` is case-insensitive.
+For the `DATE`, `START_DATE`, and `END_DATE` parameters, the keyword `today` is case-insensitive.
 </div>
 
 ### Finishing Up
@@ -562,6 +574,10 @@ delete INDEX
 * Deletes the entry at the specified `INDEX` of the currently displayed list.
 * The index refers to the index number shown in the currently displayed list.
 * The index **must be a positive integer** 1, 2, 3, …​
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+When a Company is deleted, all Persons and Events which store the company name of that Company will also be deleted.
+</div>
 
 Examples:
 * `listc` followed by `delete 2` deletes the 2nd company in the list of comapnies.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -257,8 +257,10 @@ help
 
 ### Adding entries
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-Adding an entry may fail and display an error message below if the entry already exists. You can try to do `listc s/all`/`listp s/all`/`liste s/all` to see the all the entries (archived and unarchived) in the display to make sure entryalready exists previously.
+Adding an entry may fail and display an error message if the entry already exists. You can try to do `listc s/all`/`listp s/all`/`liste s/all`
+to see all the entries (archived and unarchived) in the display. This way, you can check if the entry already exists.
 </div>
+
 #### Adding a company: `addc`
 
 Adds a company to the list of companies.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -365,7 +365,7 @@ Format:
 editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…
 ```
 
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
 If the name of a Company is edited, all Events and Persons referring to that Company will also
 update the company name they have stored.
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,7 +151,7 @@ Otherwise, if the command is **valid**, a **success message** will be shown and 
 ![successful command](images/SuccessfulCommandExample.png)
 
 --------------------------------------------------------------------------------------------------------------------
-## Features Walkthrough
+## Features Guide
 This section will help you navigate and understand the [Features](#features) section of the guide.
 This way, you can easily use it to answer any question you have regarding the app's features.
 
@@ -189,8 +189,38 @@ With a simple command standards, we tried to make the commands as intuitive as p
 
 </div>
 
+### Command Parameter Restrictions
+
+Some parameters have special restrictions on what counts as a valid input. These restrictions are listed below.
+If a parameter is not listed below, it has no special restrictions.
+
+<div markdown="block" class="alert alert-info">
+**:information_source: Note:**
+An empty input or an input consisting only of spaces is invalid for every parameter 
+</div>
+
+* `n/NAME` - Must only consist of letters or numbers
+* `c/COMPANY_NAME` - Must refer to the name of an existing Company in the app
+* `p/PHONE` - Must contain only numbers and be at least 3 digits long
+* `e/EMAIL` - Must be of the form `local-part@domain`
+* `d/DATE`, `sd/START_DATE`, and `ed/END_DATE` - Must be of one of the following forms:
+  * `YYYY-MM-DD` e.g. `2022-01-22` (It must still be a valid date)
+  * `today` (InternBuddy will interpret this as today's date)
+  * `today DAY` e.g. `today 3` (`DAY` should be an integer. InternBuddy will interpret this as `DAY` days after today's date)
+* `ti/TIME` - Must be in `HH:MM` format and be a valid time e.g. `22:40`
+* `s/SEACH_TYPE` - Must be one of `unarchived`, `archived`, or `all`
+  * If no `s/` parameter is given, InternBuddy will default to `unarchived`.
+* `o/ORDERING` - Must be either `ascending` or `descending`
+  * If no `o/` parameter is given, InternBuddy will default to `ascending`.
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The keyword "today" for `DATE`, `START_DATE`, and `END_DATE` is case-insensitive.
+</div>
+
 ### Finishing Up
-And that's all there is to it! Now that you have a basic understanding of the commands, You can now get started on learning all the important [commands](#features) you can use to organize your InternBuddy lists. Focus on that interview and get that internship! If you have any trouble, do refer back to the user guide and the [FAQ](#faq) section. Good luck! :confetti_ball: :confetti_ball: :confetti_ball:
+And that's all there is to it! Now that you have a basic understanding of the commands, You can now get started on
+learning all the important [commands](#features) you can use to organize your InternBuddy lists. If you have any trouble,
+do refer back to the user guide and the [FAQ](#faq) section. Good luck! :confetti_ball: :confetti_ball: :confetti_ball:
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -240,10 +270,6 @@ Format:
 addp n/NAME c/COMPANY_NAME p/PHONE_NUMBER e/EMAIL [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-info">:information_source: **Note:**
-`COMPANY_NAME` must match the name of an existing Company in the Company list.
-</div>
-
 Examples:
 * `addp n/John Doe c/Shopee p/98765432 e/johnd@example.com`
 * `addp n/Betsy Crowe c/DBS t/friend e/betsycrowe@example.com p/1234567 t/criminal`
@@ -257,33 +283,12 @@ Format:
 adde n/NAME c/COMPANY_NAME d/DATE ti/TIME l/LOCATION [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
-`DATE` must be in the format:
-* YYYY-MM-DD
-* "today" (which will get the `DATE` for today)
-* "today DAY" (which will get the `DATE` for DAY days after today)
-While `TIME` must be in the format HH:MM.
-E.g. 2022-10-20 and 13:30, or "today 10" and 12:45.
-</div>
-
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-the keyword "today" for DATE is case-insensitive.
-</div>
-
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
-`COMPANY_NAME` must match the name of an existing Company in the Company list.
-</div>
-
 Examples:
 * `adde n/Interview c/DBS d/2022-04-02 ti/14:00 l/Zoom`
 * `adde n/Career Talk ti/10:00 d/2022-03-19 c/Sony t/important l/22 Clementi Rd`
 * `adde n/Practical Test c/ABC d/today ti/15:00 l/Zoom`
+
 ### Listing entries
-- The `s/` parameter is an optional parameter that accepts 3 types of argument:
-  - `s/all`: returns all entries
-  - `s/archived`: returns all archived entries
-  - `s/unarchived`: returns all unarchived entries
-- If the `s/` parameter is not provided, the default is `s/unarchived`
 #### Listing all companies : `listc`
 
 Shows a list of all companies in the list of companies.
@@ -319,6 +324,7 @@ liste [s/SEARCH_TYPE]
 Examples:
 * `liste` (defaults to `s/unarchived`) displays all unarchived events.
 * `liste s/archived` displays all archived events.
+
 ### Editing entries
 <div markdown="block" class="alert alert-info">
 
@@ -334,6 +340,10 @@ Examples:
 
 </div>
 
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+You can remove all of an entry’s tags by typing `t/` without specifying any tags after it.
+</div>
+
 #### Editing a company : `editc`
 
 Edits an existing company in the list of companies.
@@ -344,19 +354,15 @@ editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…
 ```
 
 <div markdown="span" class="alert alert-primary">:information_source: **Note:**
-If the name of the Company is edited, all Events and Persons referring to the Company will also
+If the name of a Company is edited, all Events and Persons referring to that Company will also
 update the company name they have stored.
 </div>
 
 Examples:
-* `editc 1 p/91234567 e/company@example.com` Edits the phone number and email address of the 1st company to be `91234567` and `company@example.com` respectively.
-* `editc 2 n/Shoppee t/` Edits the name of the 2nd company to be `Shoppee` and clears all existing tags.
+* `editc 1 p/91234567 e/company@example.com` edits the phone number and email address of the 1st company to be `91234567` and `company@example.com` respectively.
+* `editc 2 n/Shoppee t/` edits the name of the 2nd company to be `Shoppee` and clears all existing tags.
 
 #### Editing a person : `editp`
-
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-You can remove all of an entry’s tags by typing `t/` without specifying any tags after it.
-</div>
 
 Edits an existing person in the list of contact people.
 
@@ -365,13 +371,9 @@ Format:
 editp INDEX [n/NAME] [c/COMPANY_NAME] [p/PHONE] [e/EMAIL] [t/TAG]…​
 ```
 
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
-`COMPANY_NAME` must match the name of an existing Company in the Company list.
-</div>
-
 Examples:
-*  `editp 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-*  `editp 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `editp 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
+*  `editp 2 n/Betsy Crower t/` edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
 #### Editing an event : `edite`
 
@@ -380,40 +382,27 @@ Edits an existing event in the list of events.
 Format: 
 ```
 edite INDEX [n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…
-```
-
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
-`DATE` must be in the format YYYY-MM-DD, while `TIME` must be in the format HH:MM.
-E.g. 2022-10-20 and 13:30.
-</div>
-
-<div markdown="span" class="alert alert-primary">:information_source: **Note:**
-`COMPANY_NAME` must match the name of an existing Company in the Company list.
-</div>
+``` 
 
 Examples:
-* `edite 1 d/2021-12-21 l/Zoom` Edits the date and location of the 1st event to be `2021-12-21` and `Zoom` respectively.
-* `edite 2 n/Resume Screening t/` Edits the name of the 2nd event to be `Resume Screening` and clears all existing tags.
+* `edite 1 d/2021-12-21 l/Zoom` edits the date and location of the 1st event to be `2021-12-21` and `Zoom` respectively.
+* `edite 2 n/Resume Screening t/` edits the name of the 2nd event to be `Resume Screening` and clears all existing tags.
 
 ### Locating entries
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
-* Only full words will be matched e.g. `Han` will not match `Hans`
+* The order of the keywords does not matter. e.g. `findp n/Hans Bo` is the same as `findp n/Bo Hans`
+* Only full words will be matched e.g. `findp n/Han` will not match a Person with the name `Hans`
 * Entries matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
-
-- Same for listing commands, the `s/` parameter is an optional parameter that accepts 3 types of argument:
-  - `s/all`: returns all entries
-  - `s/archived`: returns all archived entries
-  - `s/unarchived`: returns all unarchived entries
-- If the `s/` parameter is not provided, the default is `s/unarchived`
-- `KEYWORD` represents each parameter with the arguments specified after it.
+  e.g. `findp n/Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* At least one of the parameters must be provided.
+*`KEYWORD` represents each parameter with the arguments specified after it.
   i.e. `[n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…`
+
 #### Locating companies: `findc`
 
-Finds companies with given details of the company by name and tag.
+Finds all companies which have a name and tags that contain any of the given keywords and displays them as a list
+with index numbers.
 
 Format: 
 ```
@@ -426,11 +415,12 @@ Examples:
 
 #### Locating people: `findp`
 
-Finds all persons whose name, companyName, and tags contain any of the specified keywords (case-insensitive)  and displays them as a list with index numbers.
+Finds all persons whose name, company name, and tags contain any of the given keywords and displays them as a list
+with index numbers.
 
 Format: 
 ```
-findp [n/NAME] [c/COMPANY] [s/SEARCH_TYPE] [t/TAG]
+findp [n/NAME] [c/COMPANY_NAME] [s/SEARCH_TYPE] [t/TAG]
 ```
 
 Examples:
@@ -440,7 +430,8 @@ Examples:
 
 #### Locating events: `finde`
 
-Finds events with given details of the event by name, company, start date, end date, time, location and tag
+Finds all events whose name, company, start date, end date, time, location and tags contains the specified keywords
+and displays them as a list with index numbers.
 
 <div markdown="span" class="alert alert-primary">:information_source: **Note:**
 START DATE and END DATE will find events from the START DATE to the END DATE **inclusively**.
@@ -448,7 +439,7 @@ START DATE and END DATE will find events from the START DATE to the END DATE **i
 
 Format: 
 ```
-finde [n/NAME] [c/COMPANY] [sd/START DATE] [ed/END DATE] [ti/TIME] [l/LOCATION] [s/SEARCH_TYPE] [MORE_KEYWORDS]
+finde [n/NAME] [c/COMPANY_NAME] [sd/START_DATE] [ed/END_DATE] [ti/TIME] [l/LOCATION] [s/SEARCH_TYPE]
 ```
 Examples:
 * `finde n/online` returns `online interview` and `online assessment`
@@ -461,16 +452,12 @@ Examples:
 
 **:information_source: Notes about the Sort Commands:**<br>
 
-* Sort commands can take an optional parameter `Ordering` which can be `ascending` or `descending`. If not provided, `Ordering` defaults to `ascending`.
-* The parameter  `Ordering` can be passed by using `o/` followed by `ascending` or `descending`.
-* Similar to list commands, the `s/` parameter is an optional parameter that accepts 3 types of argument:
-  - `s/all`: returns all entries
-  - `s/archived`: returns all archived entries
-  - `s/unarchived`: returns all unarchived entries
+* Sort commands will sort the entry list in a certain order and display it
+* The entry list that is displayed and sorted depends on the sorting command used
 </div>
 
 #### Sorting companies by name: `sortc`
-Sort companies by name. The default is in `ascending` order. To sort in `descending` order, use `sortc o/descending`.
+Sorts companies by name. The default is in `ascending` order. To sort in `descending` order, use `sortc o/descending`.
 
 Format:
 ```
@@ -482,7 +469,7 @@ Examples:
 * `sortc s/all o/descending` returns all companies in descending order
 
 #### Sorting people by name: `sortp`
-Sort people by name. The default is in `ascending` order. To sort in `descending` order, use `sortp o/descending`.
+Sorts people by name. The default is in `ascending` order. To sort in `descending` order, use `sortp o/descending`.
 
 Format:
 ```
@@ -494,7 +481,7 @@ Examples:
 * `sortp s/all o/descending` returns all people in descending order
 
 #### Sorting events by date: `sorte`
-Sort events by date. The default is in `ascending` order. To sort in `descending` order, use `sorte o/descending`.
+Sorts events by date. The default is in `ascending` order. To sort in `descending` order, use `sorte o/descending`.
 
 Format:
 ```
@@ -505,11 +492,20 @@ Examples:
 * `sorte o/descending` returns all unarchived events in descending order
 * `sorte s/all o/descending` returns all events in descending order
 
+### Archiving entries
+
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about the Archive Commands:**<br>
+
+* Archived entries will be "hidden" from their entry list unless the user specifically searches for them
+  (e.g. by using the `s/archived` or `s/all` parameter)
+* Only unarchived entries can be archived; similarly, only archived entries can be unarchived.
+
 </div>
 
-### Archiving entries
 #### Archiving an entry: `archive`
-Archiving an entry will hide it from the list of entries.
+Archives an entry in the currently displayed list.
 
 Format:
 ```
@@ -517,14 +513,15 @@ archive INDEX
 ```
 
 Examples:
-* `archive 1` hides the 1st entry from the list of entries.
+* `archive 1` archives the 1st entry in the currently displayed list.
 
 <div markdown="span" class="alert alert-primary">:information_source: **Note:**
-display all unarchived entries first to get the INDEX of the entry you want to archive.
+Use a list, find, or sort command to get all unarchived entries first. That way, you can get the INDEX of the entry
+you want to archive.
 </div>
 
-#### Archiving entries in display: `archive_all`
-Archiving all the entries displayed in the current list (either from a list command or find/locate command).
+#### Archiving all entries in display: `archive_all`
+Archiving all the entries displayed in the currently displayed list.
 
 Format:
 ```
@@ -543,11 +540,12 @@ Examples:
 * `unarchive 1` shows the 1st entry in the list of entries.
 
 <div markdown="span" class="alert alert-primary">:information_source: **Note:**
-display all archived entries first to get the INDEX of the entry you want to unarchive.
+Use a list, find, or sort command to get all archivede entries first. That way, you can get the INDEX of the entry
+you want to unarchive.
 </div>
 
-#### Unarchiving entries in display: `unarchive_all`
-Unarchiving all the entries displayed in the current list (either from a list command or find/locate command).
+#### Unarchiving all entries in display: `unarchive_all`
+Unarchiving all the entries displayed in the currently displayed list.
 
 Format:
 ```
@@ -571,9 +569,9 @@ Examples:
 * `listc` followed by `delete 2` deletes the 2nd company in the list of comapnies.
 * `findp Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
-#### Deleting entries in display : `delete_all`
+#### Deleting all entries in display : `delete_all`
 
-Deletes all the entries displayed in the current list (either from a list command or find/locate command).
+Deletes all the entries displayed in the currently displayed list.
 
 Format: 
 ```
@@ -602,7 +600,10 @@ exit
 
 InternBuddy data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
 
-### Editing the data file [FOR ADVANCED USERS]
+### Editing the data file
+
+<div markdown="span" class="alert alert-info">:information_source: **Note:** This section is for advanced users only.
+</div>
 
 InternBuddy data are saved as a JSON file `[JAR file location]/data/internbuddy.json`. Advanced users are welcome to update data directly by editing that data file.
 
@@ -622,7 +623,6 @@ If your changes to the data file makes its format invalid, InternBuddy will disc
 
 **Q**: How do I transfer my data to another Computer?<br>
 **A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous InternBuddy home folder.
-
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -313,7 +313,7 @@ Examples:
 * `listp` (defaults to `s/unarchived`) displays all unarchived people.
 * `listp s/archived` displays all archived people.
 
-### Listing all events : `liste`
+#### Listing all events : `liste`
 
 Shows a list of all events in the list of events.
 
@@ -396,8 +396,6 @@ Examples:
 * Entries matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `findp n/Hans Bo` will return `Hans Gruber`, `Bo Yang`
 * At least one of the parameters must be provided.
-*`KEYWORD` represents each parameter with the arguments specified after it.
-  i.e. `[n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…`
 
 #### Locating companies: `findc`
 
@@ -406,7 +404,7 @@ with index numbers.
 
 Format: 
 ```
-findc [n/NAME] [s/SEARCH_TYPE] [t/TAG]
+findc [n/NAME] [s/SEARCH_TYPE] [t/TAG]…
 ```
 Examples:
 * `findc n/sgshop dbsss` returns `sgshop` and `sgshop sop` and `dbsss`
@@ -420,7 +418,7 @@ with index numbers.
 
 Format: 
 ```
-findp [n/NAME] [c/COMPANY_NAME] [s/SEARCH_TYPE] [t/TAG]
+findp [n/NAME] [c/COMPANY_NAME] [s/SEARCH_TYPE] [t/TAG]…
 ```
 
 Examples:
@@ -439,7 +437,7 @@ START DATE and END DATE will find events from the START DATE to the END DATE **i
 
 Format: 
 ```
-finde [n/NAME] [c/COMPANY_NAME] [sd/START_DATE] [ed/END_DATE] [ti/TIME] [l/LOCATION] [s/SEARCH_TYPE]
+finde [n/NAME] [c/COMPANY_NAME] [sd/START_DATE] [ed/END_DATE] [ti/TIME] [l/LOCATION] [s/SEARCH_TYPE] [t/TAG]…
 ```
 Examples:
 * `finde n/online` returns `online interview` and `online assessment`
@@ -641,25 +639,29 @@ If your changes to the data file makes its format invalid, InternBuddy will disc
 
 ## Command summary
 
-| Action             | Format                                                                           | Examples                                                                             |
-|--------------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| **Add Person**     | `addp n/NAME c/COMPANY_NAME p/PHONE_NUMBER e/EMAIL [t/TAG]… `                    | `addp n/John Doe c/Shopee p/98765432 e/johnd@example.com t/friend t/colleague`       |
-| **Add Company**    | `addc n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… `                         | `addc n/DBS t/bank e/dbs@protonmail.com p/1234567 a/31 Race Card R #02-03 t/finance` |
-| **Add Event**      | `adde n/NAME c/COMPANY_NAME d/DATE ti/TIME l/LOCATION [t/TAG]… `                 | `adde n/Career Talk c/Sony d/2022-03-19 ti/10:00 l/22 Clementi Rd t/important`       |
-| **Clear**          | `clear`                                                                          |                                                                                      |
-| **Delete**         | `delete INDEX`                                                                   | `delete 3`                                                                           |
-| **Delete all in display**          |`delete_all`                                                                          |                                                                                      |
-| **Edit Person**    | `editp INDEX [n/NAME] [c/COMPANY_NAME] [p/PHONE] [e/EMAIL] [t/TAG]…`             | `editp 1 p/91234567 e/johndoe@example.com`                                           |
-| **Edit Company**   | `editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…`                  | `editc 2 n/Shoppee t/`                                                               |
-| **Edit Event**     | `edite INDEX [n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…` | `edite 2 n/Resume Screening d/2022-12-11`                                              |
-| **Archive**     | `archive INDEX` | `archive 2`                                              |
-| **Archive all in display**          |`archive_all`                                                                          |                                                                                      |
-| **Unarchive**     | `unarchive INDEX` | `unarchive 4`                                              |
-| **Unarchive all in display**          |`unarchive_all`                                                                          |                                                                                      |
-| **Find Person**    | `findp [s/SEARCH_TYPE] KEYWORD [MORE_KEYWORDS]`                                                  | `findp n/James Jake`                                                                                     |
-| **Find Company**    | `findc [s/SEARCH_TYPE] KEYWORD [MORE_KEYWORDS]`                                                  | `findc s/unarchived n/Shopee`                                                                                     |
-| **Find Event**     | `finde [s/SEARCH_TYPE] KEYWORD [MORE_KEYWORDS]`                                                  | `finde n/Career Talk`                                                                                |
-| **List Persons**   | `listp [s/SEARCH_TYPE]`                                                                          |`listp s/all`                                                                                      |
-| **List Companies** | `listc [s/SEARCH_TYPE]`                                                                          |`listc`                                                                                      |
-| **List Events**    | `liste [s/SEARCH_TYPE]`                                                                          |`liste s/archived`                                                                                      |
-| **Help**           | `help`                                                                           |                                                                                      |
+| Action                       | Format                                                                                                          | Examples                                                                        |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| **Add Company**              | `addc n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]… `                                                        | `addc n/DBS t/bank e/dbs@example.com p/1234567 a/31 Race Road #02-03 t/finance` |
+| **Add Person**               | `addp n/NAME c/COMPANY_NAME p/PHONE_NUMBER e/EMAIL [t/TAG]… `                                                   | `addp n/John Doe c/Shopee p/98765432 e/johnd@example.com t/friend t/colleague`  |
+| **Add Event**                | `adde n/NAME c/COMPANY_NAME d/DATE ti/TIME l/LOCATION [t/TAG]… `                                                | `adde n/Career Talk c/Sony d/2022-03-19 ti/10:00 l/22 Clementi Rd t/important`  |
+| **Archive**                  | `archive INDEX`                                                                                                 | `archive 2`                                                                     |
+| **Archive all in display**   | `archive_all`                                                                                                   |                                                                                 |
+| **Clear**                    | `clear`                                                                                                         |                                                                                 |
+| **Delete**                   | `delete INDEX`                                                                                                  | `delete 3`                                                                      |
+| **Delete all in display**    | `delete_all`                                                                                                    |                                                                                 |
+| **Edit Company**             | `editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…`                                                 | `editc 2 n/Shoppee t/`                                                          |
+| **Edit Person**              | `editp INDEX [n/NAME] [c/COMPANY_NAME] [p/PHONE] [e/EMAIL] [t/TAG]…`                                            | `editp 1 p/91234567 e/johndoe@example.com`                                      |
+| **Edit Event**               | `edite INDEX [n/NAME] [c/COMPANY_NAME] [d/DATE] [ti/TIME] [l/LOCATION] [t/TAG]…`                                | `edite 2 n/Resume Screening d/2022-12-11`                                       |
+| **Exit**                     | `exit`                                                                                                          |                                                                                 |
+| **Find Company**             | `findc [n/NAME] [s/SEARCH_TYPE] [t/TAG]…`                                                                       | `findc s/unarchived n/Shopee`                                                   |
+| **Find Person**              | `findp [n/NAME] [c/COMPANY_NAME] [s/SEARCH_TYPE] [t/TAG]…`                                                      | `findp n/James Jake`                                                            |
+| **Find Event**               | `finde [n/NAME] [c/COMPANY_NAME] [sd/START_DATE] [ed/END_DATE] [ti/TIME] [l/LOCATION] [s/SEARCH_TYPE] [t/TAG]…` | `finde s/all n/Career Talk sd/2022-01-01 ed/2022-03-14`                         |
+| **Help**                     | `help`                                                                                                          |                                                                                 |
+| **List Companies**           | `listc [s/SEARCH_TYPE]`                                                                                         | `listc`                                                                         |
+| **List Persons**             | `listp [s/SEARCH_TYPE]`                                                                                         | `listp s/all`                                                                   |
+| **List Events**              | `liste [s/SEARCH_TYPE]`                                                                                         | `liste s/archived`                                                              |
+| **Sort Companies**           | `sortc [s/SEARCH_TYPE] [o/ORDERING]`                                                                            | `sortc`                                                                         |
+| **Sort Persons**             | `sortp [s/SEARCH_TYPE] [o/ORDERING]`                                                                            | `sortp s/unarchived o/ascending`                                                |
+| **Sort Events**              | `sorte [s/SEARCH_TYPE] [o/ORDERING]`                                                                            | `sortc o/descending s/archived`                                                 |
+| **Unarchive**                | `unarchive INDEX`                                                                                               | `unarchive 4`                                                                   |
+| **Unarchive all in display** | `unarchive_all`                                                                                                 |                                                                                 |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -17,7 +17,7 @@ If you're interested in using InternBuddy but don't know where to begin, this se
 1. Ensure you have Java `11` or above installed in your Computer.
    * If you don't have it installed, you can follow [Oracle's JDK installation guide](https://docs.oracle.com/en/java/javase/11/install/installation-guide.pdf)
    for your operating system.
-   * Also ensure that you have selecte Java `11` as your default Java version.
+   * Also ensure that you have selected Java `11` as your default Java version.
    * If you are not sure which version of Java that you currently have, you can follow [Java Manual](https://www.java.com/en/download/help/version_manual.html)
    to check.
 


### PR DESCRIPTION
* Generally fixes wording, errors, and typos throughout the document
* Add sortc, sortp, sorte, and exit to the Command Summary
* Split Overview and Structure of InternBuddy into its own section
* Add section explaining the restrictions on each parameter type
* Add section explaining Archive feature
* Add note that lists cannot have duplicate entries as well as notes on what counts as a duplicate entry